### PR TITLE
Asking for a single contiguous IP range

### DIFF
--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -482,6 +482,7 @@ echo "taken up by any other machines, and should not be in any"
 echo "DHCP address pools.  Faststart will split this range into"
 echo "public and private IP addresses, which will then be used"
 echo "by Eucalyptus instances."
+echo ""
 
 ipsinrange=0
 
@@ -495,7 +496,6 @@ until (( $ipsinrange==1 )); do
         read ciab_ips1
         valid_ip $ciab_ips1 || echo "Please provide a valid IP."
     done
-    echo ""
 
     echo "What's the last address of your IP range?"
     until valid_ip $ciab_ips2; do
@@ -510,20 +510,18 @@ until (( $ipsinrange==1 )); do
         # OK, subnets match
         iptail1=$(echo $ciab_ips1 | cut -d'.' -f4)
         iptail2=$(echo $ciab_ips2 | cut -d'.' -f4)
-        echo "iptail1 = $iptail1 : iptail2 = $iptail2"
         if ! (("$iptail1+9" < "$iptail2")); then
             echo "Please provide a range of at least 10 IP addresses, with the second IP greater than the first."
         else
             publicend=$(($iptail1+(($iptail2-$iptail1)/2)))
             privatestart=$(($publicend+1))
-            echo "Public end = $publicend Private start = $privatestart"
             ciab_publicips1="$ipsub1.$iptail1"
             ciab_publicips2="$ipsub1.$publicend"
             ciab_privateips1="$ipsub1.$privatestart"
             ciab_privateips2="$ipsub1.$iptail2"
             echo "OK, IP range is good"
-            echo "  Public range will be $ciab_publicips1 - $ciab_publicips2"
-            echo "  Private range will be $ciab_privateips1 - $ciab_privateips2"
+            echo "  Public range will be:   $ciab_publicips1 - $ciab_publicips2"
+            echo "  Private range will be   $ciab_privateips1 - $ciab_privateips2"
             ipsinrange=1
         fi
     else


### PR DESCRIPTION
It's clear that users who are accustomed to the old managed modes are going to provide a separate address range for the private IPs, which breaks Faststart. Instead, we'll just ask for a single address range, and we'll split it up ourselves.
