### PR TITLE
Simple wrapper script to easily launch NC mode for FastStart installer 

### DIFF
--- a/install-nc.sh
+++ b/install-nc.sh
@@ -1,0 +1,1 @@
+bash <(curl -Ls eucalyptus.com/install) --nc


### PR DESCRIPTION
Vic, _this_ PR will enable us to help users run this command to install NCs
bash <(curl -Ls eucalyptus.com/install-nc)

Hooray for branches and tags!
