### PR TITLE
Fix for issue #92

### DIFF
--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -127,9 +127,9 @@ function offer_support()
         printf "\n\n====================================\n\n" >> /tmp/$uuid/env.log
         netstat -lnp >> /tmp/$uuid/env.log
 
-        cp $LOGFILE /tmp/$uuid/ 2&>> /dev/null
-        cp -r /var/log/eucalyptus/* /tmp/$uuid/ 2&>> /dev/null
-        tar -czvf /tmp/$uuid.tar.gz /tmp/$uuid 2&>> /dev/null
+        cp $LOGFILE /tmp/$uuid/ &> /dev/null
+        cp -r /var/log/eucalyptus/* /tmp/$uuid/ &> /dev/null
+        tar -czvf /tmp/$uuid.tar.gz /tmp/$uuid &> /dev/null
         echo "put /tmp/$uuid.tar.gz" | sftp -b - -o StrictHostKeyChecking=no -o IdentityFile=/tmp/faststart-logger.priv faststart-logger@dropbox.eucalyptus.com:./uploads/
     fi
     echo ""


### PR DESCRIPTION
Fix for issue 92 - FastStart logfile uploads don't include actual log file 
Bug in the code that caused the install log file to not be bundled into the tar.gz file. 
Specifically line 130:
      cp $LOGFILE /tmp/$uuid/ 2&>> /dev/null
It seems to have upset cp. Replace /dev/null with a real file and you see:
      cp: target `2' is not a directory
Changed lines 130-132 to use a simpler redirect
