### PR TITLE
Testing

### DIFF
--- a/recipes/nuke.rb
+++ b/recipes/nuke.rb
@@ -225,11 +225,6 @@ directory "/var/chef/cache" do
   only_if "ls /var/chef/cache"
 end
 
-execute "remove all eucalyptus cache repositories" do
-  command "rm -rf /var/cache/yum/x86_64/6/euca*"
-  ignore_failure true
-end
-
 execute "Clear yum cache" do
   command "yum clean all"
 end

--- a/recipes/nuke.rb
+++ b/recipes/nuke.rb
@@ -233,3 +233,8 @@ end
 execute "Clear yum cache" do
   command "yum clean all"
 end
+
+execute "remove all eucalyptus cache repositories" do
+  command "rm -rf /var/cache/yum/x86_64/6/euca*"
+  ignore_failure true
+end


### PR DESCRIPTION
I changed the order of eucalyptus cached repositories removal because I believe that 'yum clean all' restores them.  I think we want the eucalyptus repository cache to be completely empty when we run deploy.