### PR TITLE
Remove default libvirt network

### DIFF
--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -129,6 +129,9 @@ if node["eucalyptus"]["nc"]["install-qemu-migration"]
   end
 end
 
+# Remove default virsh network which runs its own dhcp server
+execute 'virsh net-destroy default'
+
 service "eucalyptus-nc" do
   action [ :enable, :start ]
   supports :status => true, :start => true, :stop => true, :restart => true


### PR DESCRIPTION
CentOS 6.6's libvirt now binds to the default dhcp port which is needed by eucanetd. This removes that network before starting the NC and eucanetd.
