### PR TITLE
update cloud-in-a-box.sh

### DIFF
--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -319,7 +319,7 @@ if [ "$?" != "0" ]; then
     echo "======"
     echo "[FATAL] Operating system not supported"
     echo ""
-    echo "Please note: Eucalyptus Faststart only runs on RHEL or CentOS 6.5."
+    echo "Please note: Eucalyptus Faststart only runs on RHEL or CentOS 6.5 or 6.6."
     echo "To try Faststart on another platform, consider trying Eucadev:"
     echo "https://github.com/eucalyptus/eucadev"
     echo ""


### PR DESCRIPTION
Added verbosity to include CentOS/RH 6.5 & 6.6 in the error message.