### PR TITLE
faststart fails when it can't contact pool.ntp.org

### DIFF
--- a/faststart/ciab-template.json
+++ b/faststart/ciab-template.json
@@ -4,6 +4,7 @@
       "eucalyptus-repo": "http://downloads-cdn0.eucalyptus.com/software/eucalyptus/4.1/centos/6/x86_64/",
       "euca2ools-repo": "http://downloads-cdn0.eucalyptus.com/software/euca2ools/3.2/centos/6/x86_64/",
       "install-service-image": EXTRASERVICES,
+      "ntp-server": "NTP",
       "topology": {
         "clc-1": "IPADDR",
         "walrus": "IPADDR",
@@ -20,7 +21,7 @@
         "mode": "EDGE",
         "public-interface": "br0",
         "private-interface": "br0",
-        "bridged-nic":"NIC", 
+        "bridged-nic":"NIC",
         "bridge-ip": "IPADDR",
         "bridge-netmask": "NETMASK",
         "bridge-gateway": "GATEWAY",

--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -488,6 +488,7 @@ ciab_ipaddr_guess=`ifconfig $active_nic | grep "inet addr" | awk '{print $2}' | 
 ciab_gateway_guess=`/sbin/ip route | awk '/default/ { print $3 }'`
 ciab_netmask_guess=`ifconfig $active_nic | grep 'inet addr' | awk 'BEGIN{FS=":"}{print $4}'`
 ciab_subnet_guess=`ipcalc -n $ciab_ipaddr_guess $ciab_netmask_guess | cut -d'=' -f2`
+ciab_ntp_guess=`gawk '/^server / {print $2}' /etc/ntp.conf | head -1`
 
 
 echo "====="
@@ -506,6 +507,13 @@ else
 fi
 echo "Note: it's STRONGLY suggested that you accept the default values where"
 echo "they are provided, unless you know that the values are incorrect."
+
+echo ""
+echo "What's the NTP server which we will update time from? ($ciab_ntp_guess)"
+read ciab_ntp
+[[ -z "$ciab_ntp" ]] && ciab_ntp=$ciab_ntp_guess
+echo "NTP="$ciab_ntp
+echo ""
 
 echo ""
 echo "What's the physical NIC that will be used for bridging? ($ciab_nic_guess)"
@@ -692,6 +700,7 @@ sed -i "s/PRIVATEIPS1/$ciab_privateips1/g" $chef_template
 sed -i "s/PRIVATEIPS2/$ciab_privateips2/g" $chef_template
 sed -i "s/EXTRASERVICES/$ciab_extraservices/g" $chef_template
 sed -i "s/NIC/$ciab_nic/g" $chef_template
+sed -i "s/NTP/$ciab_ntp/g" $chef_template
 
 ###############################################################################
 # SECTION 4: INSTALL EUCALYPTUS


### PR DESCRIPTION
When running faststart behind a firewall, access to pool.ntp.org
may not be present. however in it's absence the setup will fail.

This change adds code to guess the locally configured ntp server
and offer the user an opportunity to elect a different server