### PR TITLE
Update source-branch to maint-4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Some common attributes are:
     <td><tt>["eucalyptus"]["source-branch"]</tt></td>
     <td>String</td>
     <td>Branch to use when building from source</td>
-    <td><tt>testing</tt></td>
+    <td><tt>maint-4.1</tt></td>
   </tr>
 </table>
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,9 +13,9 @@ Vagrant.configure("2") do |config|
       chef.roles_path = "roles"
       chef.add_role "cloud-in-a-box"  
       chef.json = { "eucalyptus" => { ## Choose whether to compile binaries from "source" or "packages"
-                                      "install-type" => "packages",
+                                      "install-type" => "source",
                                       ## Does not change package version, use "eucalyptus-repo" variable
-                                      "source-branch" => "testing",
+                                      "source-branch" => "maint-4.1",
                                       "eucalyptus-repo" => "http://downloads.eucalyptus.com/software/eucalyptus/4.1/centos/6/x86_64/",
                                       "euca2ools-repo" =>  "http://downloads.eucalyptus.com/software/euca2ools/3.2/centos/6/x86_64/",
                                       "yum-options" => "--nogpg",

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 #### Install Info
-default["eucalyptus"]["install-type"] = "source"
+default["eucalyptus"]["install-type"] = "packages"
 default["eucalyptus"]["source-repo"] = "https://github.com/eucalyptus/eucalyptus.git"
 default["eucalyptus"]["source-branch"] = "maint-4.1"
 default['eucalyptus']['rm-source-dir'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 #### Install Info
-default["eucalyptus"]["install-type"] = "packages"
+default["eucalyptus"]["install-type"] = "source"
 default["eucalyptus"]["source-repo"] = "https://github.com/eucalyptus/eucalyptus.git"
-default["eucalyptus"]["source-branch"] = "testing"
+default["eucalyptus"]["source-branch"] = "maint-4.1"
 default['eucalyptus']['rm-source-dir'] = false
 default["eucalyptus"]["eucalyptus-repo"] = "http://downloads.eucalyptus.com/software/eucalyptus/4.0/centos/6/x86_64/"
 default["eucalyptus"]["euca2ools-repo"] = "http://downloads.eucalyptus.com/software/euca2ools/3.1/centos/6/x86_64/"


### PR DESCRIPTION
The README.md indicated that the testing branch should be used
for building from source but Vic mentioned recent reorganization
of the branches.  Using maint-4.1 does work correctly when building
from source.

I also changed install-type to 'source' because that's what eucadev.md
says is default.
