### PR TITLE
key and cert limits

### DIFF
--- a/faststart/ciab-template.json
+++ b/faststart/ciab-template.json
@@ -5,6 +5,10 @@
       "euca2ools-repo": "http://downloads-cdn0.eucalyptus.com/software/euca2ools/3.2/centos/6/x86_64/",
       "install-service-image": EXTRASERVICES,
       "ntp-server": "NTP",
+      "system-properties": {
+          "authentication.access_keys_limit": 10,
+          "authentication.signing_certificates_limit": 10
+      },
       "topology": {
         "clc-1": "IPADDR",
         "walrus": "IPADDR",


### PR DESCRIPTION
Modifying to stop users tripping up on https://eucalyptus.atlassian.net/browse/EUCA-9940. Deeming this an acceptable deviation from standard security due to FastStart being a quick-start mechanism for new users.