### PR TITLE
Fix SAN from source and DAS+SAN multibackend

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -68,12 +68,17 @@ if Eucalyptus::Enterprise.is_enterprise?(node)
         san_package = 'eucalyptus-enterprise-storage-san-netapp-libs'
       when 'equallogic'
         san_package = 'eucalyptus-enterprise-storage-san-equallogic-libs'
+      else
+        # This cluster is not SAN backed
+        san_package = nil
       end
-      yum_package san_package do
-        action :upgrade
-        options node['eucalyptus']['yum-options']
-        notifies :restart, "service[eucalyptus-cloud]", :immediately
-        flush_cache [:before]
+      if san_package and node["eucalyptus"]["install-type"] == "packages"
+        yum_package san_package do
+          action :upgrade
+          options node['eucalyptus']['yum-options']
+          notifies :restart, "service[eucalyptus-cloud]", :immediately
+          flush_cache [:before]
+        end
       end
     end
   end

--- a/recipes/storage-controller.rb
+++ b/recipes/storage-controller.rb
@@ -72,19 +72,26 @@ if Eucalyptus::Enterprise.is_san?(node)
       san_package = 'eucalyptus-enterprise-storage-san-netapp'
     when 'equallogic'
       san_package = 'eucalyptus-enterprise-storage-san-equallogic'
+    else
+      # This cluster is not SAN backed
+      san_package = nil
     end
-    yum_package san_package do
-      action :upgrade
-      options node['eucalyptus']['yum-options']
-      notifies :restart, "service[eucalyptus-cloud]", :immediately
-      flush_cache [:before]
-    end
-    if Eucalyptus::Enterprise.is_vmware?(node)
-      yum_package 'eucalyptus-enterprise-vmware-broker-libs' do
-        action :upgrade
-        options node['eucalyptus']['yum-options']
-        notifies :restart, "service[eucalyptus-cloud]", :immediately
-        flush_cache [:before]
+    if node["eucalyptus"]["install-type"] == "packages"
+      if san_package
+        yum_package san_package do
+          action :upgrade
+          options node['eucalyptus']['yum-options']
+          notifies :restart, "service[eucalyptus-cloud]", :immediately
+          flush_cache [:before]
+        end
+      end
+      if Eucalyptus::Enterprise.is_vmware?(node)
+        yum_package 'eucalyptus-enterprise-vmware-broker-libs' do
+          action :upgrade
+          options node['eucalyptus']['yum-options']
+          notifies :restart, "service[eucalyptus-cloud]", :immediately
+          flush_cache [:before]
+        end
       end
     end
   end


### PR DESCRIPTION
We were missing some cases for source builds where we would try to install libs from packages. Additionally if clusters were mixed between DAS and SAN in multi cluster, the install would fail completely.