### PR TITLE
Add tag to show image source when installing a default image

### DIFF
--- a/recipes/create-first-resources.rb
+++ b/recipes/create-first-resources.rb
@@ -37,6 +37,7 @@ script "install_image" do
   curl #{node['eucalyptus']['default-img-url']} > default.img
   source #{node['eucalyptus']['admin-cred-dir']}/eucarc
   euca-install-image -i default.img -b default -n default -r x86_64 --virtualization-type hvm
+  euca-describe-images --filter name=default | sed 's/.*\(emi-.\{8\}\).*/\1/' | xargs euca-create-tags --tag source=#{node['eucalyptus']['default-img-url']}
   EOH
 end
 


### PR DESCRIPTION
Just an idea to help give some additional traceability as to the installed image's origin. 