### PR TITLE
Configure eucanetd on nodes for all network modes except VPCMIDO

### DIFF
--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -30,7 +30,7 @@ else
   include_recipe "eucalyptus::install-source"
 end
 
-if node["eucalyptus"]["network"]["mode"] == "EDGE"
+if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
   # make sure libvirt is started
   # when we want to delete its networks
   service 'libvirtd' do


### PR DESCRIPTION
In 4.2 we need eucanetd setup (and libvert cleaned) on nodes for all network modes *except* VPCMIDO. 