### PR TITLE
Swap existing iface config for bridge config

### DIFF
--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -47,6 +47,11 @@ if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
 end
 
 ## Setup Bridge
+execute "network-restart" do
+  command "service network restart"
+  action :nothing
+end
+
 network_script_directory = '/etc/sysconfig/network-scripts'
 bridged_nic = node["eucalyptus"]["network"]["bridged-nic"]
 bridge_interface = node["eucalyptus"]["network"]["bridge-interface"]
@@ -73,11 +78,7 @@ template bridged_nic_file do
   mode 0644
   owner "root"
   group "root"
-end
-
-execute "network-restart" do
-  command "service network restart"
-  action :nothing
+  notifies :run, "execute[network-restart]", :immediately
 end
 
 execute "Set ip_forward sysctl values on NC" do

--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -47,11 +47,37 @@ if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
 end
 
 ## Setup Bridge
-template "/etc/sysconfig/network-scripts/ifcfg-" + node["eucalyptus"]["network"]["bridged-nic"] do
+network_script_directory = '/etc/sysconfig/network-scripts'
+bridged_nic = node["eucalyptus"]["network"]["bridged-nic"]
+bridge_interface = node["eucalyptus"]["network"]["bridge-interface"]
+bridged_nic_file = "#{network_script_directory}/ifcfg-" + bridged_nic
+bridge_file = "#{network_script_directory}/ifcfg-" + bridge_interface
+
+execute "Copy existing interface config to bridge config" do
+  command "cp #{bridged_nic_file} #{bridge_file}"
+  not_if "ls #{bridge_file}"
+end
+
+execute "Add BRIDGE type to bridge file" do
+  command "echo 'TYPE=Bridge' >> #{bridge_file}"
+  not_if "grep 'TYPE=Bridge' #{bridge_file}"
+end
+
+execute "Set device name in bridge file" do
+  command "sed -i 's/DEVICE.*/DEVICE=#{bridge_interface}/g' #{bridge_file}"
+  not_if "grep 'DEVICE=#{bridge_interface}' #{bridge_file}"
+end
+
+template bridged_nic_file do
   source "ifcfg-eth.erb"
   mode 0644
   owner "root"
   group "root"
+end
+
+execute "network-restart" do
+  command "service network restart"
+  action :nothing
 end
 
 execute "Set ip_forward sysctl values on NC" do
@@ -69,27 +95,6 @@ end
 execute "Reload sysctl values" do
   command "sysctl -p"
 end
-
-if node["eucalyptus"]["network"]["bridge-ip"] != ""
-  bridge_template = "ifcfg-br0-static.erb"
-else
-  bridge_template = "ifcfg-br0-dhcp.erb"
-end
-
-template "/etc/sysconfig/network-scripts/ifcfg-" + node["eucalyptus"]["network"]["bridge-interface"] do
-  source bridge_template
-  mode 0644
-  owner "root"
-  group "root"
-  not_if "ls /etc/sysconfig/network-scripts/ifcfg-" + node["eucalyptus"]["network"]["bridge-interface"]
-  notifies :run, "execute[network-restart]", :immediately
-end
-
-execute "network-restart" do
-  command "service network restart"
-  action :nothing
-end
-
 
 service "messagebus" do
   supports :status => true, :restart => true, :reload => true


### PR DESCRIPTION
We were originally using templates to create the
bridge configs but this caused issues when users had
existing configuration in place. One example is a
static IP being set there. We would wipe out this config
causing a failing install. Issue #64 of calyptos.