### PR TITLE
Workaround non-determinism in walrus registration - EUCA-11400

### DIFF
--- a/recipes/register-components.rb
+++ b/recipes/register-components.rb
@@ -117,7 +117,7 @@ end
 
 if node['eucalyptus']['topology']['walrus']
   execute "Register Walrus" do
-    command "#{euca_conf} --register-walrus -P walrus -H #{node['eucalyptus']['topology']['walrus']} -C walrus-1 #{dont_sync_keys}"
+    command "#{euca_conf} --register-walrus -P walrus -H #{node['eucalyptus']['topology']['walrus']} -C walrus #{dont_sync_keys}"
     not_if "#{disable_proxy} euca-describe-services | grep walrus-1"
   end
 end


### PR DESCRIPTION
By setting the component name to walrus the idempotency of the registration request is maintained. 