### PR TITLE
Run chown on dirs with runtime stuff

### DIFF
--- a/recipes/install-source.rb
+++ b/recipes/install-source.rb
@@ -112,15 +112,12 @@ execute 'Run make' do
   timeout node["eucalyptus"]["compile-timeout"]
 end
 
-%w(/etc/eucalyptus /var/lib/eucalyptus /var/log/eucalyptus /var/run/eucalyptus).each do |runtime_dir|
-  directory runtime_dir do
-    recursive true
-    owner "eucalyptus"
-    group "eucalyptus"
-  end
+%w{/etc/eucalyptus /var/lib/eucalyptus /var/log/eucalyptus /var/run/eucalyptus}.each do |runtime_dir|
+  execute "mkdir -p #{home_directory}/#{runtime_dir}"
+  execute "chown -R eucalyptus:eucalyptus #{home_directory}/#{runtime_dir}"
 end
 
-%w(/usr/lib/eucalyptus/euca_mountwrap /usr/lib/eucalyptus/euca_rootwrap).each do |suid_exe|
+%w{/usr/lib/eucalyptus/euca_mountwrap /usr/lib/eucalyptus/euca_rootwrap}.each do |suid_exe|
   file suid_exe do
     mode '4755'
     group 'eucalyptus'


### PR DESCRIPTION
It seems the `directory` directive's `recursive` property only applies to directory creation, not everything.  This commit makes install-source use chown to accomplish that instead.