### PR TITLE
Faststart 4.2: Readme updates and DNS addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,34 @@ For cloud-in-a-box installs look at...
 For distributed topologies...
 [Deployment with motherbrain](http://testingclouds.wordpress.com/2014/03/24/install-eucalyptus-4-0-using-motherbrain-and-chef/)
 
+Faststart
+-------------------
+### Methodology
+Faststart is a Bash script, `faststart/cloud-in-a-box.sh`, that invokes the Eucalyptus cookbook in order to install a single host cloud-in-a-box install. There is an HTTP redirect in place for eucalyptus.com/install that points to that script in the master branch so that users can use the following to invoke it:
+
+    bash <(curl -sL eucalyptus.com/install)
+
+Once invoked the script does the following:
+1. Checks for necessary resources on the machine that it is installing on (ie disk, memory, virtualization extensions)
+2. Asks the user for the minimum necessary configuration parameters.
+3. Installs the Chef client
+4. Runs the Chef client in order to install Eucalyptus using the cookbook tarball and the inputs from the user.
+
+Inputs from the user are searched and replaced into the templates in `faststart/ciab-template.json` and `fastart/node-template.json` and then used as follows to run the cookbook:
+
+    chef-solo -r cookbooks.tgz -j ciab.json
+
+### Releasing
+In order to release a new version of Faststart, you must first package up the current cookbook versions with Berkshelf.
+
+1. Ensure Berkshelf is installed via the [ChefDK](https://downloads.chef.io/chef-dk/)
+2. Change directories to where your eucalyptus-cookbook repo lives.
+3. Run `berks package` to bundle all cookbook deps into a tarball, replacing VERSION with the desired release number, for example 4.2.0: `berks package eucalyptus-cookbooks-$VERSION.tgz`
+4. Upload the tarball to S3 in the euca-chef bucket, then make the object publicly readable. To test this, simply try to download the file via its URL, by using your browser. An example URL is http://euca-chef.s3.amazonaws.com/eucalyptus-cookbooks-$VERSION.tgz
+5. Change the $cookbooks_url variable in faststart/cloud-in-a-box.sh to point to your new publicly available tarball.
+6. Commit and push that change to the branch for this release, for example euca-4.2.
+7. In order to push the change live, merge the branch into master.
+
 Contributing
 ------------
 

--- a/faststart/ciab-template.json
+++ b/faststart/ciab-template.json
@@ -9,6 +9,7 @@
           "authentication.access_keys_limit": 10,
           "authentication.signing_certificates_limit": 10
       },
+      "dns": {"domain": "IPADDR.xip.io"},
       "topology": {
         "clc-1": "IPADDR",
         "walrus": "IPADDR",

--- a/faststart/ciab-template.json
+++ b/faststart/ciab-template.json
@@ -1,8 +1,8 @@
 {
     "eucalyptus": {
       "yum-options": "--nogpg",
-      "eucalyptus-repo": "http://downloads-cdn0.eucalyptus.com/software/eucalyptus/4.1/centos/6/x86_64/",
-      "euca2ools-repo": "http://downloads-cdn0.eucalyptus.com/software/euca2ools/3.2/centos/6/x86_64/",
+      "eucalyptus-repo": "http://downloads-cdn0.eucalyptus.com/software/eucalyptus/4.2/centos/6/x86_64/",
+      "euca2ools-repo": "http://downloads-cdn0.eucalyptus.com/software/euca2ools/3.3/centos/6/x86_64/",
       "install-service-image": EXTRASERVICES,
       "ntp-server": "NTP",
       "system-properties": {

--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -793,22 +793,19 @@ if [ "$nc_install_only" == "0" ]; then
 #
 # FINISH CLOUD-IN-A-BOX INSTALL
 #
-    # Add tipoftheday to the console
-    sed -i 's|<div class="clearfix">|<iframe width="0" height="0" src="https://www.eucalyptus.com/docs/tipoftheday.html?id=FSUUID" seamless="seamless" frameborder="0"></iframe>\n    <div class="clearfix">|' /usr/lib/python2.6/site-packages/eucaconsole/templates/login.pt
-sed -i "s|FSUUID|$uuid|" /usr/lib/python2.6/site-packages/eucaconsole/templates/login.pt
 
-    # Add link to open IRC window for help
-    sed -i "s|© 2014 Eucalyptus Systems, Inc.|© 2014 Eucalyptus Systems, Inc. \&nbsp; \&nbsp; \&nbsp; \&nbsp; Need help\? <a href=\"javascript:poptastic('https://kiwiirc.com/client/irc.freenode.com/eucalyptus');\">Talk to us</a> on IRC.|" /usr/lib/python2.6/site-packages/eucaconsole/templates/master_layout.pt
-sed -i "s|<metal:block metal:define-slot=\"head_js\" />|<script> var newwindow; function poptastic(url) { newwindow=window.open(url,'name','height=400,width=750'); if (window.focus) {newwindow.focus()} } </script>\n    <metal:block metal:define-slot=\"head_js\" />|" /usr/lib/python2.6/site-packages/eucaconsole/templates/master_layout.pt
+    echo ""
+    echo "[Config] Generating credentials"
+    export AWS_DEFAULT_REGION=localhost
 
     echo ""
     echo "[Config] Enabling web console"
-    source ~/eucarc && euare-useraddloginprofile --region localadmin@localhost --as-account eucalyptus -u admin -p password
+    euare-useraddloginprofile --as-account eucalyptus -u admin -p password
 
     echo "[Config] Adding ssh and http to default security group"
-    source ~/eucarc && euca-authorize -P tcp -p 22 default
-    source ~/eucarc && euca-authorize -P tcp -p 80 default
-    
+    euca-authorize -P tcp -p 22 default
+    euca-authorize -P tcp -p 80 default
+
     echo ""
     echo ""
     echo "[SUCCESS] Eucalyptus installation complete!"
@@ -829,7 +826,7 @@ sed -i "s|<metal:block metal:define-slot=\"head_js\" />|<script> var newwindow; 
                             (____/|_|
 
 To log in to the Management Console, go to:
-http://${ciab_ipaddr}:8888/
+https://${ciab_ipaddr}/
 
 Default User Credentials (unless changed):
   * Account: eucalyptus
@@ -843,7 +840,7 @@ Eucalyptus CLI Tutorials can be found at:
 EOF
 
     echo "To log in to the Management Console, go to:"
-    echo "http://${ciab_ipaddr}:8888/"
+    echo "https://${ciab_ipaddr}/"
     echo ""
     echo "User Credentials:"
     echo "  * Account: eucalyptus"
@@ -874,7 +871,7 @@ else
     echo ""
     echo "  /usr/sbin/euca_conf --register-nodes ${ciab_ipaddr}"
     echo ""
-    echo "Thanks for installing Eucalyptus!" 
+    echo "Thanks for installing Eucalyptus!"
     curl --silent "https://www.eucalyptus.com/docs/faststart_errors.html?msg=NC_INSTALL_SUCCESS&id=$uuid" >> /tmp/fsout.log
 
 fi

--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -5,7 +5,7 @@
 OPTIND=1  # Reset in case getopts has been used previously in the shell.
 
 # Initialize our own variables:
-cookbooks_url="http://euca-chef.s3.amazonaws.com/eucalyptus-cookbooks-4.1.1.tgz"
+cookbooks_url="http://euca-chef.s3.amazonaws.com/eucalyptus-cookbooks-4.2.0.tgz"
 nc_install_only=0
 
 function usage

--- a/faststart/node-template.json
+++ b/faststart/node-template.json
@@ -1,8 +1,8 @@
 {
     "eucalyptus": {
       "yum-options": "--nogpg",
-      "eucalyptus-repo": "http://downloads.eucalyptus.com/software/eucalyptus/4.1/centos/6/x86_64/",
-      "euca2ools-repo": "http://downloads.eucalyptus.com/software/euca2ools/3.2/centos/6/x86_64/",
+      "eucalyptus-repo": "http://downloads-cdn0.eucalyptus.com/software/eucalyptus/4.2/centos/6/x86_64/",
+      "euca2ools-repo": "http://downloads-cdn0.eucalyptus.com/software/euca2ools/3.3/centos/6/x86_64/",
       "network": {
         "mode": "EDGE",
         "public-interface": "br0",

--- a/recipes/create-first-resources.rb
+++ b/recipes/create-first-resources.rb
@@ -22,40 +22,56 @@
 # system that does, so we simplify the command line by simply using
 # the "localhost" region.
 as_admin = "export AWS_DEFAULT_REGION=localhost; eval `clcadmin-assume-system-credentials` && "
+faststart_ini = "/root/.euca/faststart.ini"
+
+directory '/root/.euca'
+
+execute "Create admin credentials" do
+  command "#{as_admin} euare-useraddkey admin -wld #{node["eucalyptus"]["dns"]["domain"]} -w > #{faststart_ini}"
+  creates faststart_ini
+end
+
+bash "Set default region" do
+   user "root"
+   code <<-EOF
+      echo '[global]' >> #{faststart_ini}
+      echo 'default-region = localhost' >> #{faststart_ini}
+   EOF
+   not_if "grep -q default-region #{faststart_ini}"
+end
 
 execute "Add keypair: my-first-keypair" do
-  command "#{as_admin} euca-create-keypair my-first-keypair >/root/my-first-keypair.pem && chmod 0600 /root/my-first-keypair.pem"
-  not_if "#{as_admin} euca-describe-keypairs my-first-keypair"
+  command "euca-create-keypair my-first-keypair >/root/my-first-keypair.pem && chmod 0600 /root/my-first-keypair.pem"
+  not_if "euca-describe-keypairs my-first-keypair"
   retries 10
   retry_delay 10
 end
 
 execute "Authorizing SSH and ICMP traffic for default security group" do
-  command "#{as_admin} euca-authorize -P icmp -t -1:-1 -s 0.0.0.0/0 default && euca-authorize -P tcp -p 22 -s 0.0.0.0/0 default"
+  command "euca-authorize -P icmp -t -1:-1 -s 0.0.0.0/0 default && euca-authorize -P tcp -p 22 -s 0.0.0.0/0 default"
 end
 
 script "install_image" do
   interpreter "bash"
   user "root"
   cwd "/tmp"
-  not_if "#{as_admin} euca-describe-images | grep default"
+  not_if "euca-describe-images | grep default"
   code <<-EOH
   curl #{node['eucalyptus']['default-img-url']} > default.img
-  #{as_admin} euca-install-image -i default.img -b default -n default -r x86_64 --virtualization-type hvm
+  euca-install-image -i default.img -b default -n default -r x86_64 --virtualization-type hvm
   EOH
 end
 
-
 execute "Ensure default image is public" do
-  command "#{as_admin} euca-modify-image-attribute -l -a all $(euca-describe-images | grep default | grep emi | awk '{print $2}')"
+  command "euca-modify-image-attribute -l -a all $(euca-describe-images | grep default | grep emi | awk '{print $2}')"
 end
 
 execute "Wait for resource availability" do
-  command "#{as_admin} euca-describe-availability-zones verbose | grep m1.small | grep -v 0000"
+  command "euca-describe-availability-zones verbose | grep m1.small | grep -v 0000"
   retries 50
   retry_delay 10
 end
 
 execute "Running an instance" do
-  command "#{as_admin} euca-run-instances -k my-first-keypair $(euca-describe-images | grep default | grep emi | cut -f 2)"
+  command "euca-run-instances -k my-first-keypair $(euca-describe-images | grep default | grep emi | cut -f 2)"
 end


### PR DESCRIPTION
DNS will use xip.io. This requires internet connectivity which is already presumed of any Faststart install.