### PR TITLE
use chef subscribes to force osg provider configuration to wait for u…

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -105,10 +105,12 @@ elsif node['eucalyptus']['topology']['riakcs']
   execute "#{euctl} objectstorage.s3provider.s3secretkey=#{admin_secret}"
 else
   execute "Set OSG providerclient" do
-    command "#{euctl} objectstorage.providerclient=walrus"
+    # for the short term due to errors in CI, run with --debug
+    command "#{euctl} --debug objectstorage.providerclient=walrus"
     only_if "egrep '4.[0-9].[0-9]' #{node['eucalyptus']['home-directory']}/etc/eucalyptus/eucalyptus-version"
     retries 15
     retry_delay 20
+    subscribes :start, "service[ufs-eucalyptus-cloud]", :immediately
   end
 end
 

--- a/recipes/user-facing.rb
+++ b/recipes/user-facing.rb
@@ -28,7 +28,8 @@ ruby_block "Sync keys for User Facing Services" do
   only_if { not Chef::Config[:solo] and node['eucalyptus']['sync-keys'] }
 end
 
-service "eucalyptus-cloud" do
+service "ufs-eucalyptus-cloud" do
+  service_name "eucalyptus-cloud"
   action [ :enable, :start ]
   supports :status => true, :start => true, :stop => true, :restart => true
 end


### PR DESCRIPTION
…fs service

with many failures lately in CI I have observed that the UFS service
may not be up when osg provider is set, so this will make the UFS
service a prerequisite for setting the osg provider

also use --debug for the time being in the euctl command to produce extra
output when failures are encountered (failures are unpredictable)