### PR TITLE
Set SELinux to permissive if not disabled

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -59,7 +59,7 @@ end
 
 ## Disable SELinux
 selinux_state "SELinux Disabled" do
-  action :disabled
+  action :permissive
 end
 
 ## Install repo rpms


### PR DESCRIPTION
Euca recommends setting selinux to permissive (if not disabled). 
Changing the default to permissive which should allow selinux in disabled and/or permissive states. 