### PR TITLE
Updated FastStart tutorial scripts 

### DIFF
--- a/faststart/tutorials/describe-images.sh
+++ b/faststart/tutorials/describe-images.sh
@@ -28,33 +28,38 @@ echo "Hit Enter to continue."
 read continue
 
 echo "Remember: when using Eucalyptus, you must \"log in\"."
-echo "When using euca2ools, the way to \"log in\" is to source"
-echo "the euca2ools credentials file. By default, Faststart"
-echo "installs your credentials file in the root directory."
+echo "When using euca2ools, the way to \"log in\" is to use"
+echo "the euca2ools configuration credentials file located"
+echo "under /root/.euca. By default, Faststart sets this"
+echo "configuration file up for you. Once this has been"
+echo "set up, with each euca2ools command, the"
+echo "\"--region\" option must be used. For FastStart,"
+echo "the region option will contain the value"
+echo "\"admin@localhost\".  For example:"
 echo ""
-echo "Hit Enter to run the command:"
-echo "  ${bold}source /root/eucarc${normal}"
+echo "${bold}euca-describe-availability-zones --region admin@localhost${normal}"
+echo ""
+echo "To learn more about using euca2ools configuration file, please refer to"
+echo "the Euca2ools Guide section entitled \"Working with Euca2ools Configuration Files\":"
+echo "  http://docs.hpcloud.com/eucalyptus/4.2.0/#shared/euca2ools_working_with_config_files.html"
 
 read continue
-
-echo "${bold}+ source /root/eucarc${normal}"
-source /root/eucarc
 
 echo "The euca2ools command for listing images is ${bold}euca-describe-images${normal}."
 echo "If you have ever worked with Amazon Web Services, you will"
 echo "notice that the command, and the output from the command, is"
 echo "nearly identical to the comparable AWS command; this is by design."
-echo "Press Enter to run ${bold}euca-describe-images${normal} now."
+echo "Press Enter to run ${bold}euca-describe-images --region admin@localhost${normal} now."
 
 read continue
 
-echo "${bold}+ euca-describe-images"
-euca-describe-images
+echo "${bold}+ euca-describe-images --region admin@localhost"
+euca-describe-images --region admin@localhost
 echo "${normal}"
 
 echo "Now let's review some of the key output of that command:"
 echo ""
-imagelist=`euca-describe-images | tail -n 1`
+imagelist=`euca-describe-images --region admin@localhost| tail -n 1`
 imageid=`echo $imagelist | awk '{print $2}'`
 imagepath=`echo $imagelist | awk '{print $3}'`
 public=`echo $imagelist | awk '{print $6}'`
@@ -69,4 +74,4 @@ echo "  only be run by the owner of the image are marked private."
 echo "" 
 
 echo "To learn more about the euca-describe-images command, check out the documentaion:"
-echo "  https://www.eucalyptus.com/docs/eucalyptus/3.4/index.html#euca2ools-guide/euca-describe-images.html"
+echo "  http://docs.hpcloud.com/eucalyptus/4.2.0/#euca2ools-guide/euca-describe-images.html"

--- a/faststart/tutorials/install-image.sh
+++ b/faststart/tutorials/install-image.sh
@@ -32,8 +32,6 @@ echo "Hit Enter to continue."
 
 read continue
 
-source /root/eucarc
-
 echo "Many Linux distributions now have preconfigured cloud images, so"
 echo "you can download and install them to your cloud easily. For this"
 echo "tutorial we will add a Fedora 20 cloud image to your cloud."
@@ -78,7 +76,7 @@ echo ""
 echo "OK, now you are ready to install the image into your cloud."
 echo "To install the image, we will run the following command:"
 echo ""
-echo "${bold}euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm${normal}"
+echo "${bold}euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm --region admin@localhost${normal}"
 echo ""
 echo "  ${bold}-n Fedora20${normal} specifies the name we're giving the image."
 echo "  ${bold}-b tutorial${normal} specifies the bucket we're putting the image into."
@@ -91,8 +89,8 @@ echo "Hit Enter to install the image."
 read continue
 
 # Install the image.
-echo "+ ${bold}euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm${normal}"
-euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm
+echo "+ ${bold}euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm --region admin@localhost${normal}"
+euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm --region admin@localhost
 if [ "$?" != "0" ]; then
     echo "======"
     echo "[OOPS] euca-install-image failed!"
@@ -115,9 +113,9 @@ echo "Hit Enter to modify the image attribute."
 read continue
 
 # get the EMI_ID
-EMI_ID=$(euca-describe-images | tail -n 1 | grep tutorial | grep emi | cut -f 2)
-echo "+ ${bold}euca-modify-image-attribute -l -a all $EMI_ID${normal}"
-euca-modify-image-attribute -l -a all $EMI_ID
+EMI_ID=$(euca-describe-images --region admin@localhost | grep tutorial | tail -n 1 | grep emi | cut -f 2)
+echo "+ ${bold}euca-modify-image-attribute -l -a all $EMI_ID --region admin@localhost${normal}"
+euca-modify-image-attribute -l -a all $EMI_ID --region admin@localhost
 
 echo ""
 echo "Your new Fedora machine image is installed and available to all"
@@ -128,8 +126,8 @@ echo "Hit Enter to show the list of images."
 
 read continue
 
-echo "+ ${bold}euca-describe-images${normal}"
-euca-describe-images
+echo "+ ${bold}euca-describe-images --region admin@localhost${normal}"
+euca-describe-images --region admin@localhost
 
 echo ""
 

--- a/faststart/tutorials/launch-instances.sh
+++ b/faststart/tutorials/launch-instances.sh
@@ -18,7 +18,7 @@ then
 fi
 
 # Be sure the tutorial image is installed
-EMI_ID=$(euca-describe-images | grep tutorial | grep emi | tail -n 1 | cut -f 2)
+EMI_ID=$(euca-describe-images --region admin@localhost | grep tutorial | grep emi | tail -n 1 | cut -f 2)
 echo $EMI_ID
 if [ "$EMI_ID" == "" ]
 then
@@ -29,16 +29,14 @@ then
    exit 1
 fi
 
-source /root/eucarc
-
-echo "${bold}euca-run-instances -k my-first-keypair $EMI_ID${normal}"
-euca-run-instances -k my-first-keypair $EMI_ID
+echo "${bold}euca-run-instances -k my-first-keypair $EMI_ID --region admin@localhost${normal}"
+euca-run-instances -k my-first-keypair $EMI_ID --region admin@localhost
 
 # Capture the instance ID and public address
 echo "Capturing the instance ID"
-INSTANCE_ID=$(euca-describe-instances | grep $EMI_ID | grep -v terminated | cut -f2)
+INSTANCE_ID=$(euca-describe-instances --region admin@localhost | grep $EMI_ID | grep -v terminated | cut -f2)
 echo "Capturing the public ip address"
-INSTANCE_ADDR=$(euca-describe-instances | grep $INSTANCE_ID | cut -f4)
+INSTANCE_ADDR=$(euca-describe-instances --region admin@localhost | grep $INSTANCE_ID | cut -f4)
 
 
 # Wait up to 30 seconds for the instance to start.
@@ -48,7 +46,7 @@ STATUS=
 while [ $TIMER -le 5 ]
 do
    sleep 5
-   STATUS=$(euca-describe-instances $INSTANCE_ID | grep $EMI_ID | grep running)
+   STATUS=$(euca-describe-instances $INSTANCE_ID --region admin@localhost | grep $EMI_ID | grep running)
    [ "$STATUS" != "" ] && break;
    TIMER=$(( $TIMER + 1 ))
    echo $TIMER
@@ -56,6 +54,6 @@ done
 
 # Congratulations! You can now connect to your instance
 echo "Use this command to log into your new instance"
-ehco ""
+echo ""
 echo " ssh -i ~/my-first-keypair.pem fedora@$INSTANCE_ADDR"
 echo ""


### PR DESCRIPTION
Updated following FastStart tutorial scripts to leverage euca2ools configuration file:
* faststart/tutorials/describe-images.sh
* faststart/tutorials/install-image.sh
* faststart/tutorials/launch-instances.sh
In addition, updated all the URLs to make sure they pointed to the current Eucalyptus documentation.