### PR TITLE
update eucadev with various enhancements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,9 +15,9 @@ Vagrant.configure("2") do |config|
       chef.json = { "eucalyptus" => { ## Choose whether to compile binaries from "source" or "packages"
                                       "install-type" => "source",
                                       ## Does not change package version, use "eucalyptus-repo" variable
-                                      "source-branch" => "maint-4.1",
-                                      "eucalyptus-repo" => "http://downloads.eucalyptus.com/software/eucalyptus/4.1/centos/6/x86_64/",
-                                      "euca2ools-repo" =>  "http://downloads.eucalyptus.com/software/euca2ools/3.2/centos/6/x86_64/",
+                                      "source-branch" => "maint-4.2",
+                                      "eucalyptus-repo" => "http://downloads.eucalyptus.com/software/eucalyptus/4.2/centos/6/x86_64/",
+                                      "euca2ools-repo" =>  "http://downloads.eucalyptus.com/software/euca2ools/3.3/centos/6/x86_64/",
                                       "yum-options" => "--nogpg",
                                       "default-img-url" => "http://euca-vagrant.s3.amazonaws.com/cirrosraw.img",
                                       "install-load-balancer" => false,

--- a/eucadev.md
+++ b/eucadev.md
@@ -8,7 +8,7 @@ These tools allow one to deploy a Eucalyptus cloud—in a Vagrant-provisioned VM
 
 This method produces a dev/test environment in a single virtual machine, with all Eucalyptus components deployed in it. By default, components will be built from latest source, which can be modified and immediately tested on the VM.  The source will be located on a 'synced folder' (`eucalyptus-src`), which can be edited on the host system but built on the guest system. Alternatively, you can install from latest packages, saving time.
 
-1. Install [VirtualBox](https://www.virtualbox.org)
+1. Install [VirtualBox](https://www.virtualbox.org) (You may need to install kernel-headers and other packages to load the kernel module, look at this [blog post](http://www.if-not-true-then-false.com/2010/install-virtualbox-with-yum-on-fedora-centos-red-hat-rhel/) if you have problems.)
 
 2. Install [Vagrant](http://www.vagrantup.com/) >= 1.5.2
 

--- a/eucadev/post.sh
+++ b/eucadev/post.sh
@@ -6,15 +6,7 @@
 # changes that are specific to EucaDev-based deployments 
 # and are not general enough to be part of the cookbook.
 
-#
-# Make cloud admin credentials available on the host
-#
-mkdir -p /vagrant/creds # ensure the directory exists on first run
-rm -rf /vagrant/creds/* # blow away creds from previous runs
-for FILE in eucarc iamrc jssecacerts *.pem
-do 
-	cp /root/$FILE /vagrant/creds/ # make copy
-done
-sed --in-place 's#://[^:]\+:#://127.0.0.1:#g' /vagrant/creds/eucarc # external copy should point to localhost
-source /root/eucarc
 euare-useraddloginprofile -u admin -p foobar
+
+echo "Your Eucalyptus development cloud installation is now complete!"
+

--- a/roles/cloud-in-a-box.json
+++ b/roles/cloud-in-a-box.json
@@ -7,6 +7,9 @@
       "network": {
         "public-interface": "br0",
         "private-interface": "br0"
+      },
+      "dns": {
+        "domain": "192.168.192.101.xip.io"
       }
     }
   },


### PR DESCRIPTION
1. use euca2ools configuration files versus eucarc credentials
2. point to Eucalyptus 4.2 repo & use maint-4.2 source branch
3. add xip.io address to eucalyptus:dns:domain to default
   attribute so configure.rb handles system.dns.dnsdomain properly
4. documentation update