### PR TITLE
systemd updates

### DIFF
--- a/recipes/cloud-service.rb
+++ b/recipes/cloud-service.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: eucalyptus
 # Recipe:: cloud-service
 #
-#© Copyright 2014-2016 Hewlett Packard Enterprise Development Company LP
+# © Copyright 2014-2016 Hewlett Packard Enterprise Development Company LP
 ##
 ##Licensed under the Apache License, Version 2.0 (the "License");
 ##you may not use this file except in compliance with the License.
@@ -18,12 +18,7 @@
 ##
 #
 
-# used for platform_version comparison
-require 'chef/version_constraint'
-
 include_recipe "eucalyptus::default"
-
-source_directory = "#{node['eucalyptus']["home-directory"]}/source/#{node['eucalyptus']['source-branch']}"
 
 ## Install packages for the User Facing Services
 if node["eucalyptus"]["install-type"] == "packages"
@@ -35,37 +30,6 @@ if node["eucalyptus"]["install-type"] == "packages"
   end
 else
   include_recipe "eucalyptus::install-source"
-  eucalyptus_dir = source_directory
-  if node['eucalyptus']['source-repo'].end_with?("internal")
-    eucalyptus_dir = "#{source_directory}/eucalyptus"
-  end
-  if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
-    tools_dir = "#{eucalyptus_dir}/tools"
-    execute "ln -sf #{tools_dir}/eucalyptus-cloud /etc/init.d/eucalyptus-cloud" do
-      creates "/etc/init.d/eucalyptus-nc"
-    end
-    execute "chmod +x #{tools_dir}/eucalyptus-cloud"
-  end
-  if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
-    file '/usr/lib/sysctl.d/70-eucalyptus-cloud.conf' do
-      lazy { content IO.read("#{eucalyptus_dir}/systemd/sysctl.d/70-eucalyptus-cloud.conf") }
-      mode '0644'
-      action :create
-      not_if do ::File.exists?('/usr/lib/sysctl.d/70-eucalyptus-cloud.conf') end
-    end
-    file '/usr/lib/systemd/system/eucalyptus-cloud.service' do
-      lazy { content IO.read("#{eucalyptus_dir}/systemd/units/eucalyptus-cloud.service") }
-      mode '0644'
-      action :create
-      not_if do ::File.exists?('/usr/lib/systemd/system/eucalyptus-cloud.service') end
-    end
-    file '/usr/lib/systemd/system/eucalyptus-cloud-upgrade.service' do
-      lazy { content IO.read("#{eucalyptus_dir}/systemd/units/eucalyptus-cloud-upgrade.service") }
-      mode '0644'
-      action :create
-      not_if do ::File.exists?('/usr/lib/systemd/system/eucalyptus-cloud-upgrade.service') end
-    end
-  end
 end
 
 yum_package "euca2ools" do

--- a/recipes/cloud-service.rb
+++ b/recipes/cloud-service.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: eucalyptus
 # Recipe:: cloud-service
 #
-#Copyright [2014] [Eucalyptus Systems]
+#© Copyright 2014-2016 Hewlett Packard Enterprise Development Company LP
 ##
 ##Licensed under the Apache License, Version 2.0 (the "License");
 ##you may not use this file except in compliance with the License.
@@ -18,7 +18,12 @@
 ##
 #
 
+# used for platform_version comparison
+require 'chef/version_constraint'
+
 include_recipe "eucalyptus::default"
+
+source_directory = "#{node['eucalyptus']["home-directory"]}/source/#{node['eucalyptus']['source-branch']}"
 
 ## Install packages for the User Facing Services
 if node["eucalyptus"]["install-type"] == "packages"
@@ -30,6 +35,37 @@ if node["eucalyptus"]["install-type"] == "packages"
   end
 else
   include_recipe "eucalyptus::install-source"
+  eucalyptus_dir = source_directory
+  if node['eucalyptus']['source-repo'].end_with?("internal")
+    eucalyptus_dir = "#{source_directory}/eucalyptus"
+  end
+  if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
+    tools_dir = "#{eucalyptus_dir}/tools"
+    execute "ln -sf #{tools_dir}/eucalyptus-cloud /etc/init.d/eucalyptus-cloud" do
+      creates "/etc/init.d/eucalyptus-nc"
+    end
+    execute "chmod +x #{tools_dir}/eucalyptus-cloud"
+  end
+  if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
+    file '/usr/lib/sysctl.d/70-eucalyptus-cloud.conf' do
+      lazy { content IO.read("#{eucalyptus_dir}/systemd/sysctl.d/70-eucalyptus-cloud.conf") }
+      mode '0644'
+      action :create
+      not_if do ::File.exists?('/usr/lib/sysctl.d/70-eucalyptus-cloud.conf') end
+    end
+    file '/usr/lib/systemd/system/eucalyptus-cloud.service' do
+      lazy { content IO.read("#{eucalyptus_dir}/systemd/units/eucalyptus-cloud.service") }
+      mode '0644'
+      action :create
+      not_if do ::File.exists?('/usr/lib/systemd/system/eucalyptus-cloud.service') end
+    end
+    file '/usr/lib/systemd/system/eucalyptus-cloud-upgrade.service' do
+      lazy { content IO.read("#{eucalyptus_dir}/systemd/units/eucalyptus-cloud-upgrade.service") }
+      mode '0644'
+      action :create
+      not_if do ::File.exists?('/usr/lib/systemd/system/eucalyptus-cloud-upgrade.service') end
+    end
+  end
 end
 
 yum_package "euca2ools" do

--- a/recipes/cluster-controller.rb
+++ b/recipes/cluster-controller.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: eucalyptus
 # Recipe:: default
 #
-#© Copyright 2014-2016 Hewlett Packard Enterprise Development Company LP
+# © Copyright 2014-2016 Hewlett Packard Enterprise Development Company LP
 ##
 ##Licensed under the Apache License, Version 2.0 (the "License");
 ##you may not use this file except in compliance with the License.
@@ -23,8 +23,6 @@ require 'chef/version_constraint'
 
 include_recipe "eucalyptus::default"
 
-source_directory = "#{node['eucalyptus']["home-directory"]}/source/#{node['eucalyptus']['source-branch']}"
-
 ## Install binaries for the CC
 if node["eucalyptus"]["install-type"] == "packages"
   yum_package "eucalyptus-cc" do
@@ -37,29 +35,6 @@ if node["eucalyptus"]["install-type"] == "packages"
   yum_package "dhcp"
 else
   include_recipe "eucalyptus::install-source"
-  eucalyptus_dir = source_directory
-  if node['eucalyptus']['source-repo'].end_with?("internal")
-    eucalyptus_dir = "#{source_directory}/eucalyptus"
-  end
-  if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
-    tools_dir = "#{eucalyptus_dir}/tools"
-    execute "ln -sf #{tools_dir}/eucalyptus-cloud /etc/init.d/eucalyptus-cc" do
-      creates "/etc/init.d/eucalyptus-cc"
-    end
-    execute "chmod +x #{tools_dir}/eucalyptus-cloud"
-  end
-  if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
-    file '/usr/lib/systemd/system/eucalyptus-cluster.service' do
-      lazy { content IO.read("#{eucalyptus_dir}/systemd/units/eucalyptus-cluster.service") }
-      mode '0644'
-      action :create
-      not_if do ::File.exists?('/usr/lib/systemd/system/eucalyptus-cluster.service') end
-    end
-    execute "ln -sf /usr/lib/systemd/system/eucalyptus-cluster.service /usr/lib/systemd/system/eucalyptus-cc.service" do
-      creates "/usr/lib/systemd/system/eucalyptus-cc.service"
-      not_if do ::File.exists?('/usr/lib/systemd/system/eucalyptus-cc.service') end
-    end
-  end
 end
 
 cluster_name = Eucalyptus::KeySync.get_local_cluster_name(node)

--- a/recipes/cluster-controller.rb
+++ b/recipes/cluster-controller.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: eucalyptus
 # Recipe:: default
 #
-#Copyright [2014] [Eucalyptus Systems]
+#© Copyright 2014-2016 Hewlett Packard Enterprise Development Company LP
 ##
 ##Licensed under the Apache License, Version 2.0 (the "License");
 ##you may not use this file except in compliance with the License.
@@ -17,7 +17,14 @@
 ##    limitations under the License.
 ##
 #
+
+# used for platform_version comparison
+require 'chef/version_constraint'
+
 include_recipe "eucalyptus::default"
+
+source_directory = "#{node['eucalyptus']["home-directory"]}/source/#{node['eucalyptus']['source-branch']}"
+
 ## Install binaries for the CC
 if node["eucalyptus"]["install-type"] == "packages"
   yum_package "eucalyptus-cc" do
@@ -30,6 +37,29 @@ if node["eucalyptus"]["install-type"] == "packages"
   yum_package "dhcp"
 else
   include_recipe "eucalyptus::install-source"
+  eucalyptus_dir = source_directory
+  if node['eucalyptus']['source-repo'].end_with?("internal")
+    eucalyptus_dir = "#{source_directory}/eucalyptus"
+  end
+  if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
+    tools_dir = "#{eucalyptus_dir}/tools"
+    execute "ln -sf #{tools_dir}/eucalyptus-cloud /etc/init.d/eucalyptus-cc" do
+      creates "/etc/init.d/eucalyptus-cc"
+    end
+    execute "chmod +x #{tools_dir}/eucalyptus-cloud"
+  end
+  if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
+    file '/usr/lib/systemd/system/eucalyptus-cluster.service' do
+      lazy { content IO.read("#{eucalyptus_dir}/systemd/units/eucalyptus-cluster.service") }
+      mode '0644'
+      action :create
+      not_if do ::File.exists?('/usr/lib/systemd/system/eucalyptus-cluster.service') end
+    end
+    execute "ln -sf /usr/lib/systemd/system/eucalyptus-cluster.service /usr/lib/systemd/system/eucalyptus-cc.service" do
+      creates "/usr/lib/systemd/system/eucalyptus-cc.service"
+      not_if do ::File.exists?('/usr/lib/systemd/system/eucalyptus-cc.service') end
+    end
+  end
 end
 
 cluster_name = Eucalyptus::KeySync.get_local_cluster_name(node)
@@ -67,9 +97,21 @@ if network_mode == "MANAGED" or network_mode == "MANAGED-NOVLAN"
   include_recipe "eucalyptus::eucanetd"
 end
 
-service "eucalyptus-cc" do
-  action [ :enable, :start ]
-  supports :status => true, :start => true, :stop => true, :restart => true
+# on el6 the init scripts are named differently than on el7
+# systemctl does not like unit files which are symlinks
+# so we will use the actual unit file names here
+if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
+  service "eucalyptus-cc" do
+    action [ :enable, :start ]
+    supports :status => true, :start => true, :stop => true, :restart => true
+  end
+end
+
+if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
+  service "eucalyptus-cluster" do
+    action [ :enable, :start ]
+    supports :status => true, :start => true, :stop => true, :restart => true
+  end
 end
 
 nc_ips = node['eucalyptus']['topology']['clusters'][cluster_name]['nodes'].split()

--- a/recipes/install-source.rb
+++ b/recipes/install-source.rb
@@ -2,7 +2,7 @@
 ## Cookbook Name:: eucalyptus
 ## Recipe:: install-source
 ##
-##© Copyright 2014-2016 Hewlett Packard Enterprise Development Company LP
+## © Copyright 2014-2016 Hewlett Packard Enterprise Development Company LP
 ##
 ##Licensed under the Apache License, Version 2.0 (the "License");
 ##you may not use this file except in compliance with the License.

--- a/recipes/install-source.rb
+++ b/recipes/install-source.rb
@@ -2,7 +2,7 @@
 ## Cookbook Name:: eucalyptus
 ## Recipe:: install-source
 ##
-##Copyright [2014] [Eucalyptus Systems]
+##© Copyright 2014-2016 Hewlett Packard Enterprise Development Company LP
 ##
 ##Licensed under the Apache License, Version 2.0 (the "License");
 ##you may not use this file except in compliance with the License.
@@ -186,12 +186,6 @@ if node['eucalyptus']['source-repo'].end_with?("internal")
 end
 
 tools_dir = "#{eucalyptus_dir}/tools"
-%w{eucalyptus-cloud eucalyptus-cc eucalyptus-nc}.each do |init_script|
-  execute "ln -sf #{tools_dir}/eucalyptus-cloud /etc/init.d/#{init_script}" do
-    creates "/etc/init.d/#{init_script}"
-  end
-  execute "chmod +x #{tools_dir}/eucalyptus-cloud"
-end
 
 if node["eucalyptus"]["network"]["mode"] == "EDGE"
   execute "ln -sf #{tools_dir}/eucanetd /etc/init.d/eucanetd" do

--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: eucalyptus
 # Recipe:: default
 #
-#© Copyright 2014-2016 Hewlett Packard Enterprise Development Company LP
+# © Copyright 2014-2016 Hewlett Packard Enterprise Development Company LP
 ##
 ##Licensed under the Apache License, Version 2.0 (the "License");
 ##you may not use this file except in compliance with the License.
@@ -66,41 +66,6 @@ if node["eucalyptus"]["install-type"] == "packages"
   end
 else
   include_recipe "eucalyptus::install-source"
-  eucalyptus_dir = source_directory
-  if node['eucalyptus']['source-repo'].end_with?("internal")
-    eucalyptus_dir = "#{source_directory}/eucalyptus"
-  end
-  if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
-    tools_dir = "#{eucalyptus_dir}/tools"
-    execute "ln -sf #{tools_dir}/eucalyptus-cloud /etc/init.d/eucalyptus-nc" do
-      creates "/etc/init.d/eucalyptus-nc"
-    end
-    execute "chmod +x #{tools_dir}/eucalyptus-cloud"
-  end
-  if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
-    file '/usr/lib/modules-load.d/70-eucalyptus-node.conf' do
-      lazy { content IO.read("#{eucalyptus_dir}/systemd/modules-load.d/70-eucalyptus-node.conf") }
-      mode '0644'
-      action :create
-      not_if do ::File.exists?('/usr/lib/modules-load.d/70-eucalyptus-node.conf') end
-    end
-    file '/usr/lib/systemd/system/eucalyptus-node.service' do
-      lazy { content IO.read("#{eucalyptus_dir}/systemd/units/eucalyptus-node.service") }
-      mode '0644'
-      action :create
-      not_if do ::File.exists?('/usr/lib/systemd/system/eucalyptus-node.service') end
-    end
-    file '/usr/lib/systemd/system/eucalyptus-node-keygen.service' do
-      lazy { content IO.read("#{eucalyptus_dir}/systemd/units/eucalyptus-node-keygen.service") }
-      mode '0644'
-      action :create
-      not_if do ::File.exists?('/usr/lib/systemd/system/eucalyptus-node-keygen.service') end
-    end
-    execute "ln -sf /usr/lib/systemd/system/eucalyptus-node.service /usr/lib/systemd/system/eucalyptus-nc.service" do
-      creates "/usr/lib/systemd/system/eucalyptus-nc.service"
-      not_if do ::File.exists?('/usr/lib/systemd/system/eucalyptus-nc.service') end
-    end
-  end
 end
 
 if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"

--- a/recipes/nuke.rb
+++ b/recipes/nuke.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: eucalyptus
 # Recipe:: nuke
 #
-#© Copyright 2014-2016 Hewlett Packard Enterprise Development Company LP
+# © Copyright 2014-2016 Hewlett Packard Enterprise Development Company LP
 ##
 ##Licensed under the Apache License, Version 2.0 (the "License");
 ##you may not use this file except in compliance with the License.

--- a/recipes/nuke.rb
+++ b/recipes/nuke.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: eucalyptus
 # Recipe:: nuke
 #
-#Copyright [2014] [Eucalyptus Systems]
+#© Copyright 2014-2016 Hewlett Packard Enterprise Development Company LP
 ##
 ##Licensed under the Apache License, Version 2.0 (the "License");
 ##you may not use this file except in compliance with the License.
@@ -17,9 +17,24 @@
 ##    limitations under the License.
 ##
 
+# used for platform_version comparison
+require 'chef/version_constraint'
+
 ## Stop all euca components
-service "eucalyptus-nc" do
-  action [ :stop ]
+
+# on el6 the init scripts are named differently than on el7
+# and systemctl does not like to enable unit files which are symlinks
+# so we will use the actual unit file here
+if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
+  service "eucalyptus-nc" do
+    action [ :stop ]
+  end
+end
+
+if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
+  service "eucalyptus-node" do
+    action [ :stop ]
+  end
 end
 
 if node['eucalyptus']['network']['mode'] == 'EDGE'
@@ -28,8 +43,19 @@ if node['eucalyptus']['network']['mode'] == 'EDGE'
   end
 end
 
-service "eucalyptus-cc" do
-  action [ :stop ]
+# on el6 the init scripts are named differently than on el7
+# and systemctl does not like to enable unit files which are symlinks
+# so we will use the actual unit file here
+if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
+  service "eucalyptus-cc" do
+    action [ :stop ]
+  end
+end
+
+if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
+  service "eucalyptus-cluster" do
+    action [ :stop ]
+  end
 end
 
 service "eucaconsole" do


### PR DESCRIPTION
create links to init files based on platform version (el6 or el7)

on el7 use the correct unit file name, versus the shortened name to
start and stop services (i.e. eucalyptus-node vs. eucalyptus-nc)