### PR TITLE
Bind network

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,7 +36,11 @@ default['eucalyptus']['user-console']['packaging-branch'] = "develop"
 default['eucalyptus']['admin-cred-dir'] = "/root"
 default['eucalyptus']['admin-ssh-pub-key'] = ""
 default["eucalyptus"]["home-directory"] = "/"
+# Allow the cookbooks discover the Eucalyptus service address to bind to. Requires bind-interface or bind-network to be set
 default["eucalyptus"]["set-bind-addr"] = false
+# If using 'set-bind-addr', 'bind-network' is used to locate the host address to bind to
+default["eucalyptus"]["bind-network"] = ""
+# If using 'set-bind-addr', 'bind-interface' is used to locate the host address to bind to
 # default["eucalyptus"]["bind-interface"] = 'eth0'
 default["eucalyptus"]["log-level"] = "INFO"
 default["eucalyptus"]["user"] = "eucalyptus"

--- a/libraries/bind-addr.rb
+++ b/libraries/bind-addr.rb
@@ -53,7 +53,7 @@ module Eucalyptus
                     end
                     if !bindaddrs.empty?
                         if bindaddrs.length > 1
-                            if bind_interace.nil
+                            if (!bind_interace.nil? && !bind_interface.empty?)
                                 bindaddrs.each do |iface, addr|
                                     if iface == bind_interface
                                         bind_addr = addr
@@ -61,12 +61,13 @@ module Eucalyptus
                                     end
                                 end
                             end
-                        else
+		                    end
+                        if bindaddr.nil? && bindaddrs.length > 0
                             bindaddrs.each do |iface, addr|
                                 bind_addr = addr
                                 break
                             end
-                        end
+                        end 
                     end
                     if !bind_addr.nil?
                         break

--- a/libraries/bind-addr.rb
+++ b/libraries/bind-addr.rb
@@ -17,18 +17,71 @@
 ##    limitations under the License.
 ##
 #
+require 'ipaddr'
 
 module Eucalyptus
-  module BindAddr
-    def self.get_bind_interface_ip(node)
-      bind_interface = node["eucalyptus"]["bind-interface"]
-      raise "Setting the bind interface was requested but not bind-interface parameter was set" if bind_interface.nil?
-      if node["network"]["interfaces"].has_key? bind_interface
-        bind_addr = node[:network][:interfaces][bind_interface][:addresses].find {|addr, addr_info| addr_info[:family] == "inet"}.first
-        bind_addr
-      else
-        raise "Unable to find requested bind interface #{bind_interface} on #{node["ipaddress"]}"
-      end
+    module BindAddr
+        # Attempt to find the address to bind the Eucalyptus service to based upon the provided
+        # params; bind-interface, and/or bind-network
+        def self.get_bind_interface_ip(node)
+            bind_interface = node["eucalyptus"]["bind-interface"]
+            bind_network = node["eucalyptus"]["bind-network"]
+            if bind_network.nil? && bind_interface.nil?
+                raise "set-bind-addr set to True requires at least one of bind-interface or bind-network params to be set"
+	        end
+            # First try finding the interface(s) in the bind network if provided.
+            bind_addr = nil
+            if bind_network
+                bindaddrs = {}
+                for iface in node[:network][:interfaces]
+                    if iface.is_a?(Array) && iface.length() > 1
+                        iface_name = iface[0]
+                        iface_hash = iface[1]
+                        if iface_hash.is_a?(Hash) && iface_hash.has_key?('addresses') and iface_hash['addresses'].is_a?(Hash)
+                            addresses = iface_hash['addresses']
+                            address.each do |addr, addr_info|
+                                addr_info = addresses[addr]
+                                if addr_info.is_a?(Hash) && addr_info.has_key?('family') && addr_info['family'] == "inet"
+                                    ifaceaddr = IPAddr.new(addr)
+                                    if bindnetwork.include?(ifaceaddr)
+                                        print "Got a match, iface: #{iface_name} , address: #{addr}\n"
+                                        bindaddrs[iface_name] = addr
+                                    end
+                                end
+                            end
+                        end
+                    end
+                    if !bindaddrs.empty?
+                        if bindaddrs.length > 1
+                            if bind_interace.nil
+                                bindaddrs.each do |iface, addr|
+                                    if iface == bind_interface
+                                        bind_addr = addr
+                                        break
+                                    end
+                                end
+                            end
+                        else
+                            bindaddrs.each do |iface, addr|
+                                bind_addr = addr
+                                break
+                            end
+                        end
+                    end
+                    if !bind_addr.nil?
+                        break
+                    end
+                end
+            else
+                if node["network"]["interfaces"].has_key? bind_interface
+                    bind_addr = node[:network][:interfaces][bind_interface][:addresses].find {|addr, addr_info| addr_info[:family] == "inet"}.first
+                else
+                    raise "Unable to find requested bind interface #{bind_interface} on #{node["ipaddress"]}"
+                end
+            end
+            if bind_addr.nil?
+                raise "Could not find bind address for node:#{node["ipaddress"]}. Using; bind-network:#{bind_network}, bind-interface#{bind_interface}"
+            end
+        end
     end
-  end
 end


### PR DESCRIPTION
Allow auto discovery of the bind address using a new attribute bind-network. This allows for more flexibility in the device naming and network assignment for the registration machines/interfaces. 
This method should be replaced by the previously proposed system attributes refactor.  