### PR TITLE
Bindmerge

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,7 +36,11 @@ default['eucalyptus']['user-console']['packaging-branch'] = "develop"
 default['eucalyptus']['admin-cred-dir'] = "/root"
 default['eucalyptus']['admin-ssh-pub-key'] = ""
 default["eucalyptus"]["home-directory"] = "/"
+# Allow the cookbooks discover the Eucalyptus service address to bind to. Requires bind-interface or bind-network to be set
 default["eucalyptus"]["set-bind-addr"] = false
+# If using 'set-bind-addr', 'bind-network' is used to locate the host address to bind to
+default["eucalyptus"]["bind-network"] = ""
+# If using 'set-bind-addr', 'bind-interface' is used to locate the host address to bind to
 # default["eucalyptus"]["bind-interface"] = 'eth0'
 default["eucalyptus"]["log-level"] = "INFO"
 default["eucalyptus"]["user"] = "eucalyptus"

--- a/libraries/bind-addr.rb
+++ b/libraries/bind-addr.rb
@@ -25,26 +25,31 @@ module Eucalyptus
         # params; bind-interface, and/or bind-network
         def self.get_bind_interface_ip(node)
             bind_interface = node["eucalyptus"]["bind-interface"]
-            bind_network = node["eucalyptus"]["bind-network"]
-            if bind_network.nil? && bind_interface.nil?
+            bind_network_attr = node["eucalyptus"]["bind-network"]
+		
+            if bind_network_attr.nil? && bind_interface.nil?
                 raise "set-bind-addr set to True requires at least one of bind-interface or bind-network params to be set"
 	        end
             # First try finding the interface(s) in the bind network if provided.
             bind_addr = nil
-            if bind_network
+            if bind_network_attr
                 bindaddrs = {}
+                bind_network = IPAddr.new(bind_network_attr)
+                if bind_network.to_range().count <= 1
+                    raise "bind-interface attribute does not represent a network with more than a single node?"
+                end
                 for iface in node[:network][:interfaces]
                     if iface.is_a?(Array) && iface.length() > 1
                         iface_name = iface[0]
                         iface_hash = iface[1]
                         if iface_hash.is_a?(Hash) && iface_hash.has_key?('addresses') and iface_hash['addresses'].is_a?(Hash)
                             addresses = iface_hash['addresses']
-                            address.each do |addr, addr_info|
+                            addresses.each do |addr, addr_info|
                                 addr_info = addresses[addr]
                                 if addr_info.is_a?(Hash) && addr_info.has_key?('family') && addr_info['family'] == "inet"
                                     ifaceaddr = IPAddr.new(addr)
-                                    if bindnetwork.include?(ifaceaddr)
-                                        print "Got a match, iface: #{iface_name} , address: #{addr}\n"
+                                    if bind_network.include?(ifaceaddr)
+                                        Chef::Log.info "Got a match, iface: #{iface_name} , address: #{addr}\n"
                                         bindaddrs[iface_name] = addr
                                     end
                                 end
@@ -53,7 +58,7 @@ module Eucalyptus
                     end
                     if !bindaddrs.empty?
                         if bindaddrs.length > 1
-                            if bind_interace.nil
+                            if (!bind_interace.nil? && !bind_interface.empty?)
                                 bindaddrs.each do |iface, addr|
                                     if iface == bind_interface
                                         bind_addr = addr
@@ -61,12 +66,13 @@ module Eucalyptus
                                     end
                                 end
                             end
-                        else
+		                    end
+                        if bind_addr.nil? && bindaddrs.length > 0
                             bindaddrs.each do |iface, addr|
                                 bind_addr = addr
                                 break
                             end
-                        end
+                        end 
                     end
                     if !bind_addr.nil?
                         break
@@ -80,8 +86,10 @@ module Eucalyptus
                 end
             end
             if bind_addr.nil?
-                raise "Could not find bind address for node:#{node["ipaddress"]}. Using; bind-network:#{bind_network}, bind-interface#{bind_interface}"
+                raise "Could not find bind address for node:#{node["ipaddress"]}. Using; bind-network:#{bind_network_attr}, bind-interface#{bind_interface}"
             end
+            Chef::Log.info "Found Bind addr #{bind_addr}"
+	    bind_addr
         end
     end
 end

--- a/libraries/bind-addr.rb
+++ b/libraries/bind-addr.rb
@@ -29,7 +29,7 @@ module Eucalyptus
 		
             if bind_network_attr.nil? && bind_interface.nil?
                 raise "set-bind-addr set to True requires at least one of bind-interface or bind-network params to be set"
-	        end
+	          end
             # First try finding the interface(s) in the bind network if provided.
             bind_addr = nil
             if bind_network_attr

--- a/libraries/bind-addr.rb
+++ b/libraries/bind-addr.rb
@@ -28,7 +28,7 @@ module Eucalyptus
             bind_network_attr = node["eucalyptus"]["bind-network"]
 		
             if bind_network_attr.nil? && bind_interface.nil?
-                raise "set-bind-addr set to True requires at least one of bind-interface or bind-network params to be set"
+                raise "set-bind-addr is True, this requires at least one of bind-interface or bind-network params to be set"
 	          end
             # First try finding the interface(s) in the bind network if provided.
             bind_addr = nil

--- a/libraries/bind-addr.rb
+++ b/libraries/bind-addr.rb
@@ -17,18 +17,71 @@
 ##    limitations under the License.
 ##
 #
+require 'ipaddr'
 
 module Eucalyptus
-  module BindAddr
-    def self.get_bind_interface_ip(node)
-      bind_interface = node["eucalyptus"]["bind-interface"]
-      raise "Setting the bind interface was requested but not bind-interface parameter was set" if bind_interface.nil?
-      if node["network"]["interfaces"].has_key? bind_interface
-        bind_addr = node[:network][:interfaces][bind_interface][:addresses].find {|addr, addr_info| addr_info[:family] == "inet"}.first
-        bind_addr
-      else
-        raise "Unable to find requested bind interface #{bind_interface} on #{node["ipaddress"]}"
-      end
+    module BindAddr
+        # Attempt to find the address to bind the Eucalyptus service to based upon the provided
+        # params; bind-interface, and/or bind-network
+        def self.get_bind_interface_ip(node)
+            bind_interface = node["eucalyptus"]["bind-interface"]
+            bind_network = node["eucalyptus"]["bind-network"]
+            if bind_network.nil? && bind_interface.nil?
+                raise "set-bind-addr set to True requires at least one of bind-interface or bind-network params to be set"
+	        end
+            # First try finding the interface(s) in the bind network if provided.
+            bind_addr = nil
+            if bind_network
+                bindaddrs = {}
+                for iface in node[:network][:interfaces]
+                    if iface.is_a?(Array) && iface.length() > 1
+                        iface_name = iface[0]
+                        iface_hash = iface[1]
+                        if iface_hash.is_a?(Hash) && iface_hash.has_key?('addresses') and iface_hash['addresses'].is_a?(Hash)
+                            addresses = iface_hash['addresses']
+                            address.each do |addr, addr_info|
+                                addr_info = addresses[addr]
+                                if addr_info.is_a?(Hash) && addr_info.has_key?('family') && addr_info['family'] == "inet"
+                                    ifaceaddr = IPAddr.new(addr)
+                                    if bindnetwork.include?(ifaceaddr)
+                                        print "Got a match, iface: #{iface_name} , address: #{addr}\n"
+                                        bindaddrs[iface_name] = addr
+                                    end
+                                end
+                            end
+                        end
+                    end
+                    if !bindaddrs.empty?
+                        if bindaddrs.length > 1
+                            if bind_interace.nil
+                                bindaddrs.each do |iface, addr|
+                                    if iface == bind_interface
+                                        bind_addr = addr
+                                        break
+                                    end
+                                end
+                            end
+                        else
+                            bindaddrs.each do |iface, addr|
+                                bind_addr = addr
+                                break
+                            end
+                        end
+                    end
+                    if !bind_addr.nil?
+                        break
+                    end
+                end
+            else
+                if node["network"]["interfaces"].has_key? bind_interface
+                    bind_addr = node[:network][:interfaces][bind_interface][:addresses].find {|addr, addr_info| addr_info[:family] == "inet"}.first
+                else
+                    raise "Unable to find requested bind interface #{bind_interface} on #{node["ipaddress"]}"
+                end
+            end
+            if bind_addr.nil?
+                raise "Could not find bind address for node:#{node["ipaddress"]}. Using; bind-network:#{bind_network}, bind-interface#{bind_interface}"
+            end
+        end
     end
-  end
 end

--- a/recipes/cloud-service.rb
+++ b/recipes/cloud-service.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: eucalyptus
 # Recipe:: cloud-service
 #
-# © Copyright 2014-2016 Hewlett Packard Enterprise Development Company LP
+#Copyright [2014] [Eucalyptus Systems]
 ##
 ##Licensed under the Apache License, Version 2.0 (the "License");
 ##you may not use this file except in compliance with the License.
@@ -19,6 +19,19 @@
 #
 
 include_recipe "eucalyptus::default"
+
+
+if node["eucalyptus"]["set-bind-addr"] 
+  if node["eucalyptus"]["bind-interface"] or  node["eucalyptus"]["bind-network"]
+    # Auto detect IP from interface name or network membership 
+    bind_addr = Eucalyptus::BindAddr.get_bind_interface_ip(node)
+  else
+    # Use default gw interface IP
+    bind_addr = node["ipaddress"]
+  end
+  node.override['eucalyptus']['cloud-opts'] = node['eucalyptus']['cloud-opts'] + " --bind-addr=" + bind_addr
+end
+
 
 ## Install packages for the User Facing Services
 if node["eucalyptus"]["install-type"] == "packages"
@@ -37,19 +50,9 @@ yum_package "euca2ools" do
   options node['eucalyptus']['yum-options']
 end
 
-if node["eucalyptus"]["set-bind-addr"] and not node["eucalyptus"]["cloud-opts"].include?("bind-addr")
-  if node["eucalyptus"]["bind-interface"]
-    # Auto detect IP from interface name
-    bind_addr = Eucalyptus::BindAddr.get_bind_interface_ip(node)
-  else
-    # Use default gw interface IP
-    bind_addr = node["ipaddress"]
-  end
-  node.override['eucalyptus']['cloud-opts'] = node['eucalyptus']['cloud-opts'] + " --bind-addr=" + bind_addr
-end
-
 template "eucalyptus.conf" do
   path   "#{node["eucalyptus"]["home-directory"]}/etc/eucalyptus/eucalyptus.conf"
   source "eucalyptus.conf.erb"
   action :create
+  notifies :restart, "service[eucalyptus-cloud]", :immediately
 end

--- a/recipes/storage-controller.rb
+++ b/recipes/storage-controller.rb
@@ -21,8 +21,8 @@ include_recipe "eucalyptus::default"
 ### Need to know cluster name before setting bind-addr
 
 ### Set bind-addr if necessary
-if node["eucalyptus"]["set-bind-addr"] and not node["eucalyptus"]["cloud-opts"].include?("bind-addr")
-  if node["eucalyptus"]["bind-interface"]
+if node["eucalyptus"]["set-bind-addr"] 
+  if node["eucalyptus"]["bind-interface"] or node["eucalyptus"]["bind-network"]
     # Auto detect IP from interface name
     bind_addr = Eucalyptus::BindAddr.get_bind_interface_ip(node)
   else
@@ -48,6 +48,7 @@ template "eucalyptus.conf" do
   source "eucalyptus.conf.erb"
   path "#{node["eucalyptus"]["home-directory"]}/etc/eucalyptus/eucalyptus.conf"
   action :create
+  notifies :restart, "service[eucalyptus-cloud]", :immediately
 end
 
 

--- a/recipes/walrus.rb
+++ b/recipes/walrus.rb
@@ -31,8 +31,8 @@ else
   include_recipe "eucalyptus::install-source"
 end
 
-if node["eucalyptus"]["set-bind-addr"] and not node["eucalyptus"]["cloud-opts"].include?("bind-addr")
-  if node["eucalyptus"]["bind-interface"]
+if node["eucalyptus"]["set-bind-addr"] 
+  if node["eucalyptus"]["bind-interface"] or node["eucalyptus"]["bind-network"]
     # Auto detect IP from interface name
     bind_addr = Eucalyptus::BindAddr.get_bind_interface_ip(node)
   else
@@ -46,6 +46,7 @@ template "eucalyptus.conf" do
   source "eucalyptus.conf.erb"
   path   "#{node["eucalyptus"]["home-directory"]}/etc/eucalyptus/eucalyptus.conf"
   action :create
+  notifies :restart, "service[eucalyptus-cloud]", :immediately
 end
 
 ruby_block "Sync keys for Walrus" do


### PR DESCRIPTION
Allow auto discovery of the bind address using a new attribute bind-network. This allows for more flexibility in the device naming and network assignment for the registration machines/interfaces. 
This method should be replaced by the previously proposed system attributes refactor.

This needs to be further tested with fast start as well as changing the bind addr on a running cloud.