### PR TITLE
Test for existing epel repo before installing in cookbook

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -145,7 +145,7 @@ end
 
 execute 'yum install -y *epel*.rpm' do
   cwd '/tmp'
-  not_if "ls /etc/yum.repos.d/epel*"
+  not_if "yum repolist | grep epel"
 end
 
 execute "ssh-keygen -f /root/.ssh/id_rsa -P ''" do


### PR DESCRIPTION
If an epel repo is defined in a file not named epel*, the previous
test would fail and we'd create a second epel repo.  We will now use
'yum repolist' to check for existence of the epel repo.