### PR TITLE
Test for existing epel repo before installing in cookbook

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -136,7 +136,7 @@ end
 
 execute 'yum install -y *elrepo*.rpm' do
   cwd '/tmp'
-  not_if "ls /etc/yum.repos.d/elrepo*"
+  not_if "yum repolist | grep epel"
 end
 
 execute "ssh-keygen -f /root/.ssh/id_rsa -P ''" do


### PR DESCRIPTION
If an epel repo is defined in a file not named epel*, the previous
test would fail and we'd create a second epel repo.  We will now use
'yum repolist' to check for existence of the epel repo.