### PR TITLE
Remove admin credentials in faststart nuke.sh

### DIFF
--- a/recipes/nuke.rb
+++ b/recipes/nuke.rb
@@ -226,3 +226,8 @@ end
 execute "Clear yum cache" do
   command "yum clean all"
 end
+
+execute "Remove admin credentials" do
+  command "rm -rf /root/.euca/faststart.ini"
+  ignore_failure true
+end


### PR DESCRIPTION
If users attempt to run faststart more than once the faststart.ini
will not be populated with updated creds if it already exists.