### PR TITLE
Added fix for AWS_DEFAULT_REGION issue

### DIFF
--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -784,7 +784,6 @@ if [ "$nc_install_only" == "0" ]; then
 
     echo ""
     echo "[Config] Generating credentials"
-    export AWS_DEFAULT_REGION=localhost
 
     echo ""
     echo "[Config] Enabling web console"

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -17,7 +17,7 @@
 ##    limitations under the License.
 ##
 disable_proxy = 'http_proxy=""'
-as_admin = "export AWS_DEFAULT_REGION=localhost; eval `clcadmin-assume-system-credentials` && "
+as_admin = "eval `clcadmin-assume-system-credentials` && "
 command_prefix = "#{as_admin} #{node['eucalyptus']['home-directory']}"
 describe_services = "#{command_prefix}/usr/bin/euserv-describe-services"
 euctl = "#{command_prefix}/usr/bin/euctl"
@@ -254,8 +254,8 @@ end
 
 if node['eucalyptus']['network']['mode'] == 'VPCMIDO'
   execute 'Create default VPC for eucalyptus account' do
-    command "#{as_admin} euca-create-vpc `euare-accountlist | grep '^eucalyptus' | awk '{print $2}'`"
-    not_if "#{as_admin} euca-describe-vpcs | grep 'VPC.*default.*true'"
+    command "#{as_admin} euca-create-vpc `euare-accountlist | grep '^eucalyptus' | awk '{print $2}'` --region localhost"
+    not_if "#{as_admin} euca-describe-vpcs --region localhost | grep 'VPC.*default.*true'"
   end
 end
 

--- a/recipes/create-first-resources.rb
+++ b/recipes/create-first-resources.rb
@@ -21,13 +21,13 @@
 # If the CLC doesn't run user-api services it should redirect to a
 # system that does, so we simplify the command line by simply using
 # the "localhost" region.
-as_admin = "export AWS_DEFAULT_REGION=localhost; eval `clcadmin-assume-system-credentials` && "
+as_admin = "eval `clcadmin-assume-system-credentials` && "
 faststart_ini = "/root/.euca/faststart.ini"
 
 directory '/root/.euca'
 
 execute "Create admin credentials" do
-  command "#{as_admin} euare-useraddkey admin -wld #{node["eucalyptus"]["dns"]["domain"]} -w > #{faststart_ini}"
+  command "#{as_admin} euare-useraddkey admin -wld #{node["eucalyptus"]["dns"]["domain"]} -w > #{faststart_ini} --region localhost"
   creates faststart_ini
 end
 

--- a/recipes/register-components.rb
+++ b/recipes/register-components.rb
@@ -34,7 +34,7 @@ end
 
 ##### Register clusters
 clusters = node["eucalyptus"]["topology"]["clusters"]
-as_admin = "export AWS_DEFAULT_REGION=localhost; eval `clcadmin-assume-system-credentials` && "
+as_admin = "eval `clcadmin-assume-system-credentials` && "
 command_prefix = "#{as_admin} #{node['eucalyptus']['home-directory']}"
 register_service = "#{command_prefix}/usr/bin/euserv-register-service"
 describe_services = "#{command_prefix}/usr/bin/euserv-describe-services"


### PR DESCRIPTION
This is a fix for the issue mentioned in [QA-522](https://eucalyptus.atlassian.net/browse/QA-522).  In short, AWS_DEFAULT_REGION was removed, and ```--region localhost``` was used in its place where needed.