### PR TITLE
Make sure cloud service resource is available for cloud-service

### DIFF
--- a/recipes/cloud-service.rb
+++ b/recipes/cloud-service.rb
@@ -32,6 +32,11 @@ else
   include_recipe "eucalyptus::install-source"
 end
 
+service "eucalyptus-cloud" do
+  action [ :enable, :start ]
+  supports :status => true, :start => true, :stop => true, :restart => true
+end
+
 yum_package "euca2ools" do
   action :upgrade
   options node['eucalyptus']['yum-options']


### PR DESCRIPTION
cloud-service.rb does not always have the service[eucalyptus-cloud] resource when it runs. The end of the recipe's eucalyptus.conf template notifies this resource and can cause failures. 