### PR TITLE
create new ceph-rgw user for new cloud in EQS

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -122,5 +122,5 @@ default["eucalyptus"]["nc"]["instance-path"] = "/var/lib/eucalyptus/instances"
 default["eucalyptus"]["nc"]["ipset-maxsets"] = "2048"
 
 # ceph-rgw
-default['eucalyptus']['topology']['ceph-radosgw']['access-key'] == nil
-default['eucalyptus']['topology']['ceph-radosgw']['secret-key'] == nil
+default['eucalyptus']['topology']['ceph-radosgw']['access-key'] = nil
+default['eucalyptus']['topology']['ceph-radosgw']['secret-key'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -124,3 +124,4 @@ default["eucalyptus"]["nc"]["ipset-maxsets"] = "2048"
 # ceph-rgw
 default['eucalyptus']['topology']['ceph-radosgw']['access-key'] = nil
 default['eucalyptus']['topology']['ceph-radosgw']['secret-key'] = nil
+default['eucalyptus']['topology']['ceph-radosgw'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -120,3 +120,7 @@ default["eucalyptus"]["nc"]["hypervisor"] = "kvm"
 default["eucalyptus"]["nc"]["max-cores"] = "0"
 default["eucalyptus"]["nc"]["instance-path"] = "/var/lib/eucalyptus/instances"
 default["eucalyptus"]["nc"]["ipset-maxsets"] = "2048"
+
+# ceph-rgw
+default['eucalyptus']['topology']['ceph-radosgw']['access-key'] == nil
+default['eucalyptus']['topology']['ceph-radosgw']['secret-key'] == nil

--- a/libraries/ceph.rb
+++ b/libraries/ceph.rb
@@ -1,3 +1,5 @@
+require "json"
+
 module CephHelper
   module SetCephRbd
 
@@ -113,6 +115,19 @@ module CephHelper
           file.insert_line_if_no_match("/CEPH_KEYRING_PATH=\"/etc/ceph/#{file_name}\"/", "CEPH_KEYRING_PATH=\"/etc/ceph/#{file_name}\"")
           file.insert_line_if_no_match("/CEPH_CONFIG_PATH=\"/etc/ceph/ceph.conf\"/", "CEPH_CONFIG_PATH=\"/etc/ceph/ceph.conf\"")
           file.write_file
+        end
+      end
+    end
+
+    def self.get_radosgw_user_creds(node)
+      ufses = node['eucalyptus']['topology']['user-facing']
+      ufses.each do |ufs|
+        Chef::Log.debug "trying: #{ufs}"
+        found = Chef::Search::Query.new.search(:node, "addresses:#{ufs}").first.first
+        if found.attributes['eucalyptus']['topology']['ceph-radosgw']['access-key']
+          Chef::Log.debug "found: #{found}"
+          return found
+          break
         end
       end
     end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -116,8 +116,18 @@ elsif node['eucalyptus']['topology']['ceph-radosgw']
     retries 15
     retry_delay 20
   end
-  execute "#{euctl} objectstorage.s3provider.s3accesskey=#{node['eucalyptus']['topology']['ceph-radosgw']['access-key']}"
-  execute "#{euctl} objectstorage.s3provider.s3secretkey=#{node['eucalyptus']['topology']['ceph-radosgw']['secret-key']}"
+
+  ceph_access_key = node['eucalyptus']['topology']['ceph-radosgw']['access-key']
+  ceph_secret_key = node['eucalyptus']['topology']['ceph-radosgw']['secret-key']
+
+  if ceph_access_key == nil || ceph_secret_key == nil
+    found = CephHelper::SetCephRbd.get_radosgw_user_creds(node)
+    ceph_access_key = found['eucalyptus']['topology']['ceph-radosgw']['access-key']
+    ceph_secret_key = found['eucalyptus']['topology']['ceph-radosgw']['secret-key']
+  end
+
+  execute "#{euctl} objectstorage.s3provider.s3accesskey=#{ceph_access_key}"
+  execute "#{euctl} objectstorage.s3provider.s3secretkey=#{ceph_secret_key}"
   execute "#{euctl} objectstorage.s3provider.s3endpointheadresponse=200"
 else
   execute "Set OSG providerclient" do

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -328,7 +328,6 @@ ruby_block "Install Service Image" do
         :error => cmd.stderr
       }
       Chef::Log.info "#{service_image}"
-      Chef::Log.info "service_image[:error].empty?: #{service_image[:error].empty?}"
       if !service_image[:error].empty?
         raise Exception.new("Failed to fetch property because of: #{service_image[:error]}")
       end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -279,57 +279,79 @@ clusters.each do |cluster, info|
 end
 
 ### Register Service Image
-if node['eucalyptus']['install-service-image']
-  if node['eucalyptus']['service-image-repo'] != ""
-    yum_repository "eucalyptus-service-image" do
-      description "Eucalyptus Service Image Repo"
-      url node["eucalyptus"]["service-image-repo"]
-      gpgcheck false
+yum_repository "eucalyptus-service-image" do
+  description "Eucalyptus Service Image Repo"
+  url node["eucalyptus"]["service-image-repo"]
+  gpgcheck false
+  only_if { node['eucalyptus']['service-image-repo'] != "" }
+end
+
+yum_package "eucalyptus-service-image" do
+  action :upgrade
+  options node['eucalyptus']['yum-options']
+  only_if { node['eucalyptus']['install-service-image'] }
+end
+
+execute "Set imaging VM instance type" do
+  command "#{euctl} services.imaging.worker.instance_type=#{node['eucalyptus']['imaging-vm-type']}"
+  retries 15
+  retry_delay 20
+  only_if { node['eucalyptus']['imaging-vm-type'] }
+end
+
+execute "Set loadbalancing VM instance type" do
+  command "#{euctl} services.loadbalancing.worker.instance_type=#{node['eucalyptus']['loadbalancing-vm-type']}"
+  retries 15
+  retry_delay 20
+  only_if { node['eucalyptus']['loadbalancing-vm-type'] }
+end
+
+ruby_block "Install Service Image" do
+  block do
+
+    osg_urls = []
+    # Add the service url for each OSG to try next
+    node["eucalyptus"]["topology"]["user-facing"].each do |ufs|
+      osg_urls.push("http://#{ufs}:8773/services/objectstorage/")
     end
-  end
-  yum_package "eucalyptus-service-image" do
-    action :upgrade
-    options node['eucalyptus']['yum-options']
-  end
-  if node['eucalyptus']['imaging-vm-type']
-    execute "Set imaging VM instance type" do
-      command "#{euctl} services.imaging.worker.instance_type=#{node['eucalyptus']['imaging-vm-type']}"
-      retries 15
-      retry_delay 20
+
+    if node['eucalyptus']['dns']['domain']
+      osg_urls.push("http://s3.#{node["eucalyptus"]["dns"]["domain"]}:8773/")
     end
-  end
-  if node['eucalyptus']['loadbalancing-vm-type']
-    execute "Set loadbalancing VM instance type" do
-      command "#{euctl} services.loadbalancing.worker.instance_type=#{node['eucalyptus']['loadbalancing-vm-type']}"
-      retries 15
-      retry_delay 20
+    osg_urls.each do |osg_url|
+      Chef::Log.info "Attempting to install service image using s3 url: #{osg_url}"
+      cmd = Mixlib::ShellOut::new("#{euctl} services.imaging.worker.image")
+      cmd.run_command
+      service_image = {
+        :result => cmd.stdout,
+        :is_configured => cmd.stdout !~ /NULL/,
+        :error => cmd.stderr
+      }
+      Chef::Log.info "#{service_image}"
+      Chef::Log.info "service_image[:error].empty?: #{service_image[:error].empty?}"
+      if !service_image[:error].empty?
+        raise Exception.new("Failed to fetch property because of: #{service_image[:error]}")
+      end
+
+      if service_image[:is_configured]
+        break
+      else
+        cmd = Mixlib::ShellOut.new("#{as_admin} S3_URL=#{osg_url} esi-install-image --region localhost --install-default")
+        cmd.run_command
+        Chef::Log.info "cmd.stdout: #{cmd.stdout}"
+        if !cmd.stderr.empty?
+          raise Exception.new("Failed to install Service Image")
+        end
+      end
     end
+
   end
-  #Attempt to use DNS for services but do fall back to internal URIs if it fails
-  # This will allow the deployment to proceed despite external dependencies
-  osg_urls = []
-  # Add the service url for each OSG to try next
-  node["eucalyptus"]["topology"]["user-facing"].each do |ufs|
-    osg_urls.push("http://#{ufs}:8773/services/objectstorage/")
-  end
-  # Add the DNS service url
-  if node['eucalyptus']['dns']['domain']
-    osg_urls.push("http://s3.#{node["eucalyptus"]["dns"]["domain"]}:8773/")
-  end
-  osg_urls.each do |osg_url|
-    esi_cmd = "#{as_admin} S3_URL=#{osg_url} esi-install-image --region localhost --install-default"
-    Chef::Log.info "Attempting to install service image using s3 url: #{osg_url}"
-    execute esi_cmd do
-      retries 2
-      retry_delay 20
-      only_if "#{euctl} services.imaging.worker.image | grep 'NULL'"
-    end
-  end
-  execute "#{as_admin} esi-manage-stack --region localhost -a create imaging" do
-    only_if "#{euctl} services.imaging.worker.configured | grep 'false'"
-  end
-else
-  Chef::Log.info("Not installing service image due to eucalyptus::install-service-image attribute set to false")
+  only_if { node['eucalyptus']['install-service-image'] }
+end
+
+execute "create_imaging_worker" do
+  command "#{as_admin} esi-manage-stack --region localhost -a create imaging"
+  only_if "#{euctl} services.imaging.worker.configured | grep 'false'"
 end
 
 node['eucalyptus']['system-properties'].each do |key, value|

--- a/recipes/user-facing.rb
+++ b/recipes/user-facing.rb
@@ -61,7 +61,7 @@ template "#{radosgw['keyring']}" do
     :keyring => radosgw
   )
   action :create
-  only_if { node['eucalyptus']['topology']['ceph-radosgw'] }
+  only_if { node['eucalyptus']['topology']['ceph-keyrings']['radosgw'] }
 end
 
 template "#{adminkeyring['keyring']}" do
@@ -70,7 +70,7 @@ template "#{adminkeyring['keyring']}" do
     :keyring => adminkeyring
   )
   action :create
-  only_if { node['eucalyptus']['topology']['ceph-radosgw'] }
+  only_if { node['eucalyptus']['topology']['ceph-keyrings']['ceph-admin'] }
 end
 
 ruby_block "Create New Ceph User" do
@@ -88,7 +88,6 @@ ruby_block "Create New Ceph User" do
     node.save
   end
   only_if { node['eucalyptus']['topology']['ceph-radosgw']['access-key'] == nil || node['eucalyptus']['topology']['ceph-radosgw']['secret-key'] == nil }
-  only_if { node['eucalyptus']['topology']['ceph-radosgw'] }
 end
 
 ruby_block "Sync keys for User Facing Services" do

--- a/recipes/user-facing.rb
+++ b/recipes/user-facing.rb
@@ -23,50 +23,72 @@ return if node.recipe?("eucalyptus::cloud-controller")
 
 include_recipe "eucalyptus::cloud-service"
 
-if node['eucalyptus']['topology']['ceph-radosgw']
-  # TODO: write individual recipe for osg and move this section
-  if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
-    yum_repository "ceph-hammer" do
-      description "Ceph Hammer Package Repo"
-      url "http://download.ceph.com/rpm-hammer/el6/x86_64/"
-      gpgcheck false
+
+# TODO: write individual recipe for osg and move this section
+yum_repository "ceph-hammer" do
+  description "Ceph Hammer Package Repo"
+  url "http://download.ceph.com/rpm-hammer/el6/x86_64/"
+  gpgcheck false
+  only_if { Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version']) }
+end
+
+yum_repository "ceph-hammer" do
+  description "Ceph Hammer Package Repo"
+  url "http://download.ceph.com/rpm-hammer/el7/x86_64/"
+  gpgcheck false
+  only_if { Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version']) }
+end
+
+radosgw = node['eucalyptus']['topology']['ceph-keyrings']['radosgw']
+adminkeyring = node['eucalyptus']['topology']['ceph-keyrings']['ceph-admin']
+
+yum_package "ceph-radosgw" do
+  action :upgrade
+  flush_cache [:before]
+  only_if { node['eucalyptus']['topology']['ceph-radosgw'] }
+end
+
+template "/etc/ceph/ceph.conf" do
+  source "ceph.conf.erb"
+  action :create
+  only_if { node['eucalyptus']['topology']['ceph-radosgw'] }
+  notifies :restart, 'service[ceph-radosgw]', :delayed
+end
+
+template "#{radosgw['keyring']}" do
+  source "client-keyring.erb"
+  variables(
+    :keyring => radosgw
+  )
+  action :create
+  only_if { node['eucalyptus']['topology']['ceph-radosgw'] }
+end
+
+template "#{adminkeyring['keyring']}" do
+  source "client-keyring.erb"
+  variables(
+    :keyring => adminkeyring
+  )
+  action :create
+  only_if { node['eucalyptus']['topology']['ceph-radosgw'] }
+end
+
+ruby_block "Create New Ceph User" do
+  block do
+    if node['eucalyptus']['topology']['ceph-radosgw']['username']
+      new_username = node['eucalyptus']['topology']['ceph-radosgw']['username']
+    else
+      raise Exception.new("'username' not found in node['eucalyptus']['topology']['ceph-radosgw']")
     end
-  end
 
-  if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
-    yum_repository "ceph-hammer" do
-      description "Ceph Hammer Package Repo"
-      url "http://download.ceph.com/rpm-hammer/el7/x86_64/"
-      gpgcheck false
-    end
+    Chef::Log.info "ACCESS_KEY and/or SECRET_KEY not found. Creating new user: #{new_username}"
+    new_user = JSON.parse(%x[radosgw-admin user create --uid=#{new_username} --display-name="#{new_username}"])
+    node.set['eucalyptus']['topology']['ceph-radosgw']['access-key'] = new_user['keys'][0]['access_key']
+    node.set['eucalyptus']['topology']['ceph-radosgw']['secret-key'] = new_user['keys'][0]['secret_key']
+    node.save
   end
-
-  yum_package "ceph-radosgw" do
-    action :upgrade
-    flush_cache [:before]
-  end
-
-  template "/etc/ceph/ceph.conf" do
-    source "ceph.conf.erb"
-    action :create
-  end
-
-  if node['eucalyptus']['topology']['ceph-keyrings']['radosgw']
-    radosgw = node['eucalyptus']['topology']['ceph-keyrings']['radosgw']
-    template "#{radosgw['keyring']}" do
-      source "client-keyring.erb"
-      variables(
-        :keyring => radosgw
-      )
-      action :create
-    end
-  end
-
-  service "ceph-radosgw" do
-    service_name "ceph-radosgw"
-    action [ :enable, :start ]
-    supports :status => true, :start => true, :stop => true, :restart => true
-  end
+  only_if { node['eucalyptus']['topology']['ceph-radosgw']['access-key'] == nil || node['eucalyptus']['topology']['ceph-radosgw']['secret-key'] == nil }
+  only_if { node['eucalyptus']['topology']['ceph-radosgw'] }
 end
 
 ruby_block "Sync keys for User Facing Services" do
@@ -74,6 +96,12 @@ ruby_block "Sync keys for User Facing Services" do
     Eucalyptus::KeySync.get_cloud_keys(node)
   end
   only_if { not Chef::Config[:solo] and node['eucalyptus']['sync-keys'] }
+end
+
+service "ceph-radosgw" do
+  service_name "ceph-radosgw"
+  action :nothing
+  supports :status => true, :start => true, :stop => true, :restart => true
 end
 
 service "ufs-eucalyptus-cloud" do

--- a/templates/default/client-keyring.erb
+++ b/templates/default/client-keyring.erb
@@ -3,6 +3,9 @@
   <% if @keyring['key'] -%>
   key = <%= @keyring['key'] %>
   <% end %>
+  <% if @keyring['caps mds'] -%>
+  caps mds = <%= @keyring['caps mds'] %>
+  <% end %>
   <% if @keyring['caps mon'] -%>
   caps mon = <%= @keyring['caps mon'] %>
   <% end %>


### PR DESCRIPTION
To create new user, only `username` needs to be present in the `ceph-radosgw` section of the environment YAML file.
In this case, `ceph-admin` credentials needs to be provided in the `ceph-keyrings` section, which is required to run `radosgw-admin` commands while creating new user.

```
      ceph-keyrings:
        radosgw:
          caps mon: allow rwx
          caps osd: allow rwx
          key: <RADOSGW/KEYRING>==
          keyring: /etc/ceph/ceph.client.radosgw.keyring
          name: client.radosgw.euca-osg
        ceph-admin:
          caps mds: "allow"
          caps mon: "allow *"
          caps osd: "allow *"
          key: <ADMIN/KEYRING>==
          keyring: /etc/ceph/ceph.client.admin.keyring
          name: client.admin
      ceph-radosgw:
        username: zootopia
        endpoint: localhost:7480
        keyring: /etc/ceph/ceph.client.radosgw.keyring
        log file: /var/log/ceph/radosgw.log
        name: client.radosgw.euca-osg
        rgw frontends: civetweb port=7480
```

For existing ceph-radosgw user, `access-key` and `secret-key` needs to be present instead of `username`.
```
      ceph-radosgw:
        access-key: "XFI6AAQAAXLYAA8AAOAA"
        secret-key: "haaad9BBBCCBdCSZc333zMrLLkriI5HUqBACdeF"
        endpoint: localhost:7480
        keyring: /etc/ceph/ceph.client.radosgw.keyring
        log file: /var/log/ceph/radosgw.log
````

Changes in the second commit are not related to original issue (apologies for single PR)
This commit modifies the service image installation procedures and breaks this into multiple chef resource blocks to make the blocks idempotent and less error prone.