### PR TITLE
Explicitly install admin-tools package

### DIFF
--- a/recipes/cloud-service.rb
+++ b/recipes/cloud-service.rb
@@ -41,6 +41,10 @@ if node["eucalyptus"]["install-type"] == "packages"
     notifies :create, "template[eucalyptus.conf]", :immediately
     flush_cache [:before]
   end
+  yum_package "eucalyptus-admin-tools" do
+    action :upgrade
+    options node['eucalyptus']['yum-options']
+  end
 else
   include_recipe "eucalyptus::install-source"
 end


### PR DESCRIPTION
This may not be necessary as I think that other packages should include this as a dep. However, in the mean time until we sort that out this change will install admin-tools to unblock package builds in EQS.