### PR TITLE
Set httpd_can_network_connect on VPCMIDO CLCs

### DIFF
--- a/recipes/cloud-controller.rb
+++ b/recipes/cloud-controller.rb
@@ -35,6 +35,11 @@ if node["eucalyptus"]["network"]["mode"] == "VPCMIDO"
     action :upgrade
     options node['eucalyptus']['yum-options']
   end
+  if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
+    execute "setsebool httpd_can_network_connect true" do
+      command "/usr/sbin/setsebool -P httpd_can_network_connect 1"
+    end
+  end
 end
 
 service "eucalyptus-cloud" do


### PR DESCRIPTION
The non-namespaced copy of nginx that eucanetd spawns connects to eucalyptus-cloud on port 8773. In order to make SELinux happy with this one must run setsebool -P httpd_can_network_connect 1 on the machine running the CLC, similar to what we have to do for eucaconsole.

This fixes [QA-664](https://eucalyptus.atlassian.net/browse/QA-664).