### PR TITLE
Rework sysctl configuration

### DIFF
--- a/recipes/cloud-controller.rb
+++ b/recipes/cloud-controller.rb
@@ -42,6 +42,10 @@ if node["eucalyptus"]["network"]["mode"] == "VPCMIDO"
   end
 end
 
+execute "Configure kernel parameters from 70-eucalyptus-cloud.conf" do
+  command "/usr/lib/systemd/systemd-sysctl 70-eucalyptus-cloud.conf"
+end
+
 service "eucalyptus-cloud" do
   action [ :enable, :start ]
   supports :status => true, :start => true, :stop => true, :restart => true

--- a/recipes/cluster-controller.rb
+++ b/recipes/cluster-controller.rb
@@ -58,20 +58,8 @@ template "eucalyptus.conf" do
   action :create
 end
 
-execute "Set ip_forward sysctl values on CC" do
-  command "sed -i 's/net.ipv4.ip_forward.*/net.ipv4.ip_forward = 1/' /etc/sysctl.conf"
-end
-
-execute "Set bridge-nf-call-iptables sysctl values on NC" do
-  command "sed -i 's/net.bridge.bridge-nf-call-iptables.*/net.bridge.bridge-nf-call-iptables = 1/' /etc/sysctl.conf"
-end
-
 execute "Ensure bridge modules loaded into the kernel on NC" do
   command "modprobe bridge"
-end
-
-execute "Reload sysctl values" do
-  command "sysctl -p"
 end
 
 network_mode = node["eucalyptus"]["network"]["mode"]

--- a/recipes/eucanetd.rb
+++ b/recipes/eucanetd.rb
@@ -9,6 +9,10 @@ else
   include_recipe "eucalyptus::install-source"
 end
 
+execute "Configure kernel parameters from 70-eucanetd.conf" do
+  command "/usr/lib/systemd/systemd-sysctl 70-eucanetd.conf"
+end
+
 template "#{node["eucalyptus"]["home-directory"]}/etc/eucalyptus/eucalyptus.conf" do
   source "eucalyptus.conf.erb"
   action :create

--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -173,30 +173,18 @@ if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
   end
 end
 
-execute "Set ip_forward sysctl values on NC" do
-  command "sed -i 's/net.ipv4.ip_forward.*/net.ipv4.ip_forward = 1/' /etc/sysctl.conf"
-end
-
-execute "Set bridge-nf-call-iptables sysctl values on NC" do
-  command "sed -i 's/net.bridge.bridge-nf-call-iptables.*/net.bridge.bridge-nf-call-iptables = 1/' /etc/sysctl.conf"
-end
-
-execute "Ensure bridge modules loaded into the kernel on NC" do
-  command "modprobe bridge"
-end
-
 ## use a different notifier to setup bridge in VPCMIDO mode
 if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
-  execute "Reload sysctl values" do
-    command "sysctl -p"
+  execute "Ensure bridge modules loaded into the kernel on NC" do
+    command "modprobe bridge"
     notifies :run, "execute[network-restart]", :immediately
     notifies :run, "execute[brctl setfd]", :delayed
     notifies :run, "execute[brctl sethello]", :delayed
     notifies :run, "execute[brctl stp]", :delayed
   end
 else
-  execute "Reload sysctl values" do
-    command "sysctl -p"
+  execute "Ensure bridge modules loaded into the kernel on NC" do
+    command "modprobe bridge"
     notifies :run, "execute[ifup-br0]", :immediately
   end
 end


### PR DESCRIPTION
Use systemd-sysctl to set kernel parameters.

Move the eucanetd specific parameters into the eucanetd.rb recipe.

Move notifiers in the NC recipe to the "modprobe bridge" block since
the "sysctl -p" command is no longer necessary.