### PR TITLE
fix lsmod syntax

### DIFF
--- a/recipes/install-source.rb
+++ b/recipes/install-source.rb
@@ -22,12 +22,12 @@ require 'chef/version_constraint'
 
 execute 'remove kvm_intel module if loaded' do
   command 'modprobe -r kvm_intel'
-  only_if { 'lsmod kvm_intel' }
+  only_if { '/sbin/lsmod | grep kvm_intel' }
 end
 
 execute 'remove kvm module if loaded' do
   command 'modprobe -r kvm'
-  only_if { 'lsmod kvm' }
+  only_if { '/sbin/lsmod | grep kvm' }
 end
 
 ### Create eucalyptus user


### PR DESCRIPTION
`lsmod` doesn't take any arguments.

Thus `lsmod kvm_intel` or `lsmod kvm` always return `1` (`false`),

e.g
```
# lsmod kvm_intel
Usage: lsmod
# echo $?
1
```