### PR TITLE
Change the default behavior of the eucalyptus-nc service to enable only

### DIFF
--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -266,14 +266,14 @@ end
 # so we will use the actual unit file names here
 if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
   service "eucalyptus-nc" do
-    action [ :enable, :start ]
+    action [ :enable ]
     supports :status => true, :start => true, :stop => true, :restart => true
   end
 end
 
 if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
   service "eucalyptus-node" do
-    action [ :enable, :start ]
+    action [ :enable ]
     supports :status => true, :start => true, :stop => true, :restart => true
   end
 end


### PR DESCRIPTION
With the recent updates to restart the service when the eucalyptus.conf
changes we were getting a restart and a start in sequential order.
This should make (re)start happen only once at the end of the recipe.