### PR TITLE
Remove -release from package repository names

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -85,7 +85,7 @@ else
 end
 
 ## Install repo rpms
-yum_repository "eucalyptus-release" do
+yum_repository "eucalyptus" do
   description "Eucalyptus Package Repo"
   url node["eucalyptus"]["eucalyptus-repo"]
   gpgkey node["eucalyptus"]["eucalyptus-gpg-key"]
@@ -111,7 +111,7 @@ if Eucalyptus::Enterprise.is_enterprise?(node)
     EOH
     mode "0700"
   end
-  yum_repository "eucalyptus-enterprise-release" do
+  yum_repository "eucalyptus-enterprise" do
     description "Eucalyptus Enterprise Package Repo"
     url node["eucalyptus"]["enterprise-repo"]
     gpgkey node["eucalyptus"]["eucalyptus-gpg-key"]
@@ -122,7 +122,7 @@ if Eucalyptus::Enterprise.is_enterprise?(node)
   end
 end
 
-yum_repository "euca2ools-release" do
+yum_repository "euca2ools" do
   description "Euca2ools Package Repo"
   url node["eucalyptus"]["euca2ools-repo"]
   gpgkey node["eucalyptus"]["euca2ools-gpg-key"]

--- a/recipes/nuke.rb
+++ b/recipes/nuke.rb
@@ -129,6 +129,27 @@ if node['eucalyptus']['home-directory'] != '/'
 end
 
 ## Remove repo rpms
+yum_repository 'eucalyptus' do
+  description 'Eucalyptus Package Repo'
+  url node['eucalyptus']['eucalyptus-repo']
+  gpgkey node['eucalyptus']['eucalyptus-gpg-key']
+  action :remove
+end
+
+yum_repository 'eucalyptus-enterprise' do
+  description 'Eucalyptus Enterprise Package Repo'
+  url node['eucalyptus']['enterprise-repo']
+  gpgkey node['eucalyptus']['eucalyptus-gpg-key']
+  action :remove
+end
+
+yum_repository 'euca2ools' do
+  description 'Euca2ools Package Repo'
+  url node['eucalyptus']['euca2ools-repo']
+  gpgkey node['eucalyptus']['euca2ools-gpg-key']
+  action :remove
+end
+
 yum_repository 'eucalyptus-release' do
   description 'Eucalyptus Package Repo'
   url node['eucalyptus']['eucalyptus-repo']


### PR DESCRIPTION
A "-release" suffix is generally part of the name of the package that contains a repository's config, not the repository itself.  I have no idea why this irks me so much, but for some reason it does, so here's a patch that brings what the cookbook deploys into line with what production installations will see.  The "nuke" recipe retains the old names in addition to the new names to ensure that it works on machines that predate this change.