### PR TITLE
Remove RHEL 6-specific bits from install-source

### DIFF
--- a/recipes/install-source.rb
+++ b/recipes/install-source.rb
@@ -232,19 +232,6 @@ if node['eucalyptus']['source-repo'].end_with?("internal")
   eucalyptus_dir = "#{source_directory}/eucalyptus"
 end
 
-tools_dir = "#{eucalyptus_dir}/tools"
-
-if node["eucalyptus"]["network"]["mode"] == "EDGE"
-  execute "ln -sf #{tools_dir}/eucanetd /etc/init.d/eucanetd" do
-    creates "/etc/init.d/eucanetd"
-  end
-  execute "chmod +x #{tools_dir}/eucanetd"
-end
-
-execute "Copy Policy Kit file for NC" do
-  command "cp #{tools_dir}/eucalyptus-nc-libvirt.pkla /var/lib/polkit-1/localauthority/10-vendor.d/"
-end
-
 ### Add udev rules
 directory '/etc/udev/rules.d'
 directory '/etc/udev/scripts'


### PR DESCRIPTION
I'm working on purging RHEL 6-specifics from eucalyptus to simplify things, but this currently causes build failures because the install-source recipe runs chmod on eucanetd's init script, which I removed.  Since we don't need to support 6 in the mainline branch, this commit simply removes the code corresponding to two el6-specific files that I removed.