### PR TITLE
Add eucalyptus user to libvirt group on NCs

### DIFF
--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -77,6 +77,11 @@ if node["eucalyptus"]["install-type"] == "packages"
   end
 else
   include_recipe "eucalyptus::install-source"
+  group 'libvirt' do
+    action :manage
+    members 'eucalyptus'
+    append true
+  end
 end
 
 # make sure libvirt is started now in case


### PR DESCRIPTION
On RHEL 7 membership in the libvirt group allows one to talk to libvirtd.  We do this for the eucalyptus user in packaging, but not in the cookbook, where we apparently papered over that omission with a .pkla file until commit 3963720.