### PR TITLE
Migrate to new build distribution server

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,8 +30,8 @@ suites:
       - recipe[eucalyptus::create-first-resources]
     attributes:
       eucalyptus: 
-        "eucalyptus-repo": "http://packages.release.eucalyptus-systems.com/yum/tags/eucalyptus-devel/centos/6/x86_64/"
-        "euca2ools-repo": "http://packages.release.eucalyptus-systems.com/yum/tags/euca2ools-devel/centos/6/x86_64/"
+        "eucalyptus-repo": "http://builds.qa1.eucalyptus-systems.com/packages/tags/eucalyptus-devel/centos/6/x86_64/"
+        "euca2ools-repo": "http://builds.qa1.eucalyptus-systems.com/packages/tags/euca2ools-devel/centos/6/x86_64/"
         "yum-options": "--nogpg"
         nc:
           hypervisor: qemu

--- a/environments/eucalyptus-ceph.json
+++ b/environments/eucalyptus-ceph.json
@@ -63,8 +63,8 @@
         "bridged-nic": "em1"
       },
       "init-script-url": "https://gist.githubusercontent.com/tbeckham/2e3a3ea403f3a6cbe92a/raw/datapath-network-interface",
-      "eucalyptus-repo": "http://packages.release.eucalyptus-systems.com/yum/tags/eucalyptus-devel/centos/6/x86_64/",
-      "euca2ools-repo": "http://packages.release.eucalyptus-systems.com/yum/tags/euca2ools-devel/centos/6/x86_64/",
+      "eucalyptus-repo": "http://builds.qa1.eucalyptus-systems.com/packages/tags/eucalyptus-devel/centos/6/x86_64/",
+      "euca2ools-repo": "http://builds.qa1.eucalyptus-systems.com/packages/tags/euca2ools-devel/centos/6/x86_64/",
       "ceph-baseurl": "http://ceph.com/rpm-giant/el6/x86_64/",
       "ceph-gpgkey": "https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc",
       "yum-options": "--nogpg"

--- a/faststart/ciab-template.json
+++ b/faststart/ciab-template.json
@@ -1,7 +1,7 @@
 {
     "eucalyptus": {
       "yum-options": "--nogpg",
-      "eucalyptus-repo": "http://packages.release.eucalyptus-systems.com/yum/tags/eucalyptus-devel/rhel/$releasever/$basearch/",
+      "eucalyptus-repo": "http://builds.qa1.eucalyptus-systems.com/packages/tags/eucalyptus-devel/rhel/$releasever/$basearch/",
       "euca2ools-repo": "http://downloads.eucalyptus.com/software/euca2ools/3.3/centos/7/x86_64/",
       "install-service-image": EXTRASERVICES,
       "ntp-server": "NTP",

--- a/faststart/node-template.json
+++ b/faststart/node-template.json
@@ -1,7 +1,7 @@
 {
     "eucalyptus": {
       "yum-options": "--nogpg",
-      "eucalyptus-repo": "http://packages.release.eucalyptus-systems.com/yum/tags/eucalyptus-devel/rhel/$releasever/$basearch/",
+      "eucalyptus-repo": "http://builds.qa1.eucalyptus-systems.com/packages/tags/eucalyptus-devel/rhel/$releasever/$basearch/",
       "euca2ools-repo": "http://downloads.eucalyptus.com/software/euca2ools/3.3/centos/7/x86_64/",
       "ntp-server": "NTP",
       "network": {


### PR DESCRIPTION
packages.release.eucalyptus-systems.com retired earlier this month.  This patch moves the cookbook over to its replacement.