### PR TITLE
Check for broken objectstorage state; use $IP.xip.io in faststart.ini

### DIFF
--- a/faststart/tutorials/describe-images.sh
+++ b/faststart/tutorials/describe-images.sh
@@ -3,6 +3,16 @@
 bold=`tput bold`
 normal=`tput sgr0`
 
+region=`grep domain ../../../../ciab.json | egrep -o '([0-9]{1,3}\.){3}[0-9]{1,3}.xip.io'`
+if [ "${region}" = "" ]
+then
+    echo "ERROR: Cannot determine region from file ../../../../ciab.json"
+    echo "Please verify that this tutorial is being run in the directory "
+    echo "/root/cookbooks/eucalyptus/faststart/tutorials where we expect it to"
+    echo "be run."
+    exit 1
+fi
+
 echo ""
 echo ""
 echo "${bold}Listing Images${normal}"
@@ -35,9 +45,9 @@ echo "configuration file up for you. Once this has been"
 echo "set up, with each euca2ools command, the"
 echo "\"--region\" option must be used. For FastStart,"
 echo "the region option will contain the value"
-echo "\"admin@localhost\".  For example:"
+echo "\"admin@${region}\".  For example:"
 echo ""
-echo "${bold}euca-describe-availability-zones --region admin@localhost${normal}"
+echo "${bold}euca-describe-availability-zones --region admin@${region}${normal}"
 echo ""
 echo "To learn more about using euca2ools configuration file, please refer to"
 echo "the Euca2ools Guide section entitled \"Working with Euca2ools Configuration Files\":"
@@ -49,17 +59,17 @@ echo "The euca2ools command for listing images is ${bold}euca-describe-images${n
 echo "If you have ever worked with Amazon Web Services, you will"
 echo "notice that the command, and the output from the command, is"
 echo "nearly identical to the comparable AWS command; this is by design."
-echo "Press Enter to run ${bold}euca-describe-images --region admin@localhost${normal} now."
+echo "Press Enter to run ${bold}euca-describe-images --region admin@${region}${normal} now."
 
 read continue
 
-echo "${bold}+ euca-describe-images --region admin@localhost"
-euca-describe-images --region admin@localhost
+echo "${bold}+ euca-describe-images --region admin@${region}"
+euca-describe-images --region admin@${region}
 echo "${normal}"
 
 echo "Now let's review some of the key output of that command:"
 echo ""
-imagelist=`euca-describe-images --region admin@localhost| tail -n 1`
+imagelist=`euca-describe-images --region admin@${region}| tail -n 1`
 imageid=`echo $imagelist | awk '{print $2}'`
 imagepath=`echo $imagelist | awk '{print $3}'`
 public=`echo $imagelist | awk '{print $6}'`

--- a/faststart/tutorials/install-image.sh
+++ b/faststart/tutorials/install-image.sh
@@ -7,6 +7,16 @@
 bold=`tput bold`
 normal=`tput sgr0`
 
+region=`grep domain ../../../../ciab.json | egrep -o '([0-9]{1,3}\.){3}[0-9]{1,3}.xip.io'`
+if [ "${region}" = "" ]
+then
+    echo "ERROR: Cannot determine region from file ../../../../ciab.json"
+    echo "Please verify that this tutorial is being run in the directory "
+    echo "/root/cookbooks/eucalyptus/faststart/tutorials where we expect it to"
+    echo "be run."
+    exit 1
+fi
+
 echo ""
 echo ""
 echo "${bold}Installing Images${normal}"
@@ -76,7 +86,7 @@ echo ""
 echo "OK, now you are ready to install the image into your cloud."
 echo "To install the image, we will run the following command:"
 echo ""
-echo "${bold}euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm --region admin@localhost${normal}"
+echo "${bold}euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm --region admin@${region}${normal}"
 echo ""
 echo "  ${bold}-n Fedora20${normal} specifies the name we're giving the image."
 echo "  ${bold}-b tutorial${normal} specifies the bucket we're putting the image into."
@@ -89,8 +99,8 @@ echo "Hit Enter to install the image."
 read continue
 
 # Install the image.
-echo "+ ${bold}euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm --region admin@localhost${normal}"
-euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm --region admin@localhost
+echo "+ ${bold}euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm --region admin@${region}${normal}"
+euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm --region admin@${region}
 if [ "$?" != "0" ]; then
     echo "======"
     echo "[OOPS] euca-install-image failed!"
@@ -113,9 +123,9 @@ echo "Hit Enter to modify the image attribute."
 read continue
 
 # get the EMI_ID
-EMI_ID=$(euca-describe-images --region admin@localhost | grep tutorial | tail -n 1 | grep emi | cut -f 2)
-echo "+ ${bold}euca-modify-image-attribute -l -a all $EMI_ID --region admin@localhost${normal}"
-euca-modify-image-attribute -l -a all $EMI_ID --region admin@localhost
+EMI_ID=$(euca-describe-images --region admin@${region} | grep tutorial | tail -n 1 | grep emi | cut -f 2)
+echo "+ ${bold}euca-modify-image-attribute -l -a all $EMI_ID --region admin@${region}${normal}"
+euca-modify-image-attribute -l -a all $EMI_ID --region admin@${region}
 
 echo ""
 echo "Your new Fedora machine image is installed and available to all"
@@ -126,8 +136,8 @@ echo "Hit Enter to show the list of images."
 
 read continue
 
-echo "+ ${bold}euca-describe-images --region admin@localhost${normal}"
-euca-describe-images --region admin@localhost
+echo "+ ${bold}euca-describe-images --region admin@${region}${normal}"
+euca-describe-images --region admin@${region}
 
 echo ""
 

--- a/faststart/tutorials/launch-instances.sh
+++ b/faststart/tutorials/launch-instances.sh
@@ -3,6 +3,16 @@
 bold=`tput bold`
 normal=`tput sgr0`
 
+region=`grep domain ../../../../ciab.json | egrep -o '([0-9]{1,3}\.){3}[0-9]{1,3}.xip.io'`
+if [ "${region}" = "" ]
+then
+    echo "ERROR: Cannot determine region from file ../../../../ciab.json"
+    echo "Please verify that this tutorial is being run in the directory "
+    echo "/root/cookbooks/eucalyptus/faststart/tutorials where we expect it to"
+    echo "be run."
+    exit 1
+fi
+
 echo ""
 echo ""
 echo "${bold}Launching Instances${normal}"
@@ -18,7 +28,7 @@ then
 fi
 
 # Be sure the tutorial image is installed
-EMI_ID=$(euca-describe-images --region admin@localhost | grep tutorial | grep emi | tail -n 1 | cut -f 2)
+EMI_ID=$(euca-describe-images --region admin@${region} | grep tutorial | grep emi | tail -n 1 | cut -f 2)
 echo $EMI_ID
 if [ "$EMI_ID" == "" ]
 then
@@ -29,14 +39,14 @@ then
    exit 1
 fi
 
-echo "${bold}euca-run-instances -k my-first-keypair $EMI_ID --region admin@localhost${normal}"
-euca-run-instances -k my-first-keypair $EMI_ID --region admin@localhost
+echo "${bold}euca-run-instances -k my-first-keypair $EMI_ID --region admin@${region}${normal}"
+euca-run-instances -k my-first-keypair $EMI_ID --region admin@${region}
 
 # Capture the instance ID and public address
 echo "Capturing the instance ID"
-INSTANCE_ID=$(euca-describe-instances --region admin@localhost | grep $EMI_ID | grep -v terminated | cut -f2)
+INSTANCE_ID=$(euca-describe-instances --region admin@${region} | grep $EMI_ID | grep -v terminated | cut -f2)
 echo "Capturing the public ip address"
-INSTANCE_ADDR=$(euca-describe-instances --region admin@localhost | grep $INSTANCE_ID | cut -f4)
+INSTANCE_ADDR=$(euca-describe-instances --region admin@${region} | grep $INSTANCE_ID | cut -f4)
 
 
 # Wait up to 30 seconds for the instance to start.
@@ -46,7 +56,7 @@ STATUS=
 while [ $TIMER -le 5 ]
 do
    sleep 5
-   STATUS=$(euca-describe-instances $INSTANCE_ID --region admin@localhost | grep $EMI_ID | grep running)
+   STATUS=$(euca-describe-instances $INSTANCE_ID --region admin@${region} | grep $EMI_ID | grep running)
    [ "$STATUS" != "" ] && break;
    TIMER=$(( $TIMER + 1 ))
    echo $TIMER

--- a/faststart/tutorials/master-tutorial.sh
+++ b/faststart/tutorials/master-tutorial.sh
@@ -3,6 +3,16 @@
 bold=`tput bold`
 normal=`tput sgr0`
 
+region=`grep domain ../../../../ciab.json | egrep -o '([0-9]{1,3}\.){3}[0-9]{1,3}.xip.io'`
+if [ "${region}" = "" ]
+then
+    echo "ERROR: Cannot determine region from file ../../../../ciab.json"
+    echo "Please verify that this tutorial is being run in the directory "
+    echo "/root/cookbooks/eucalyptus/faststart/tutorials where we expect it to"
+    echo "be run."
+    exit 1
+fi
+
 echo ""
 echo "*****"
 echo ""

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -202,7 +202,35 @@ if Eucalyptus::Enterprise.is_enterprise?(node)
   end
 end
 
-%w{objectstorage compute cloudformation}.each do |service|
+%w{objectstorage}.each do |service|
+  ruby_block "Block until #{service} ready" do
+    block do
+        # stole loop from:
+        # https://github.com/chef-cookbooks/aws/blob/bd40e6c668e3975a1bbb1e82361c462db646c221/providers/elastic_ip.rb#L70-L89
+        begin
+            # Timeout.timeout() apparently can't take the #{} chef
+            # variable construct so use ruby @ instance variable instead
+            @seconds = node['eucalyptus']['configure-service-timeout']
+            Timeout.timeout(@seconds) do
+                Chef::Log.info "Setting a #{node['eucalyptus']['configure-service-timeout']} second timeout and waiting for #{service} to be ready."
+                loop do
+                    if EucalyptusHelper.getservicestates?("#{service}",["enabled", "broken"])
+                        Chef::Log.info "#{service} service ready, continuing..."
+                        break
+                    else
+                        Chef::Log.info "#{service} service state not ready, sleeping 5 seconds."
+                    end
+                    sleep 5
+                end
+            end
+            rescue Timeout::Error
+                raise "Timed out waiting for #{service} to be ready after #{node['eucalyptus']['configure-service-timeout']} seconds"
+            end
+    end
+  end
+end
+
+%w{compute cloudformation}.each do |service|
   ruby_block "Block until #{service} ready" do
     block do
         # stole loop from:

--- a/recipes/create-first-resources.rb
+++ b/recipes/create-first-resources.rb
@@ -49,9 +49,6 @@ execute "Add keypair: my-first-keypair" do
 end
 
 execute "Authorizing SSH and ICMP traffic for default security group" do
-  #command "euca-authorize --region localhost -P icmp -t -1:-1 -s 0.0.0.0/0
-  #default --debug && euca-authorize --region localhost -P tcp -p 22 -s 0.0
-  #.0.0/0 default --debug"
   command "euca-authorize --region #{node["eucalyptus"]["dns"]["domain"]} -P icmp -t -1:-1 -s 0.0.0.0/0 default --debug && euca-authorize --region #{node["eucalyptus"]["dns"]["domain"]} -P tcp -p 22 -s 0.0.0.0/0 default --debug"
 end
 

--- a/recipes/create-first-resources.rb
+++ b/recipes/create-first-resources.rb
@@ -27,7 +27,7 @@ faststart_ini = "/root/.euca/faststart.ini"
 directory '/root/.euca'
 
 execute "Create admin credentials" do
-  command "#{as_admin} euare-useraddkey admin -wld #{node["eucalyptus"]["dns"]["domain"]} -w > #{faststart_ini} --region localhost"
+  command "#{as_admin} euare-useraddkey admin -wld #{node["eucalyptus"]["dns"]["domain"]} -w > #{faststart_ini} --region #{node["eucalyptus"]["dns"]["domain"]}"
   creates faststart_ini
   not_if { ::File.exist? "#{faststart_ini}" }
 end
@@ -36,20 +36,23 @@ bash "Set default region" do
    user "root"
    code <<-EOF
       echo '[global]' >> #{faststart_ini}
-      echo 'default-region = localhost' >> #{faststart_ini}
+      echo 'default-region = #{node["eucalyptus"]["dns"]["domain"]}' >> #{faststart_ini}
    EOF
    not_if "grep -q default-region #{faststart_ini}"
 end
 
 execute "Add keypair: my-first-keypair" do
-  command "euca-create-keypair my-first-keypair >/root/my-first-keypair.pem && chmod 0600 /root/my-first-keypair.pem"
-  not_if "euca-describe-keypairs my-first-keypair"
+  command "euca-create-keypair --region #{node["eucalyptus"]["dns"]["domain"]} my-first-keypair >/root/my-first-keypair.pem && chmod 0600 /root/my-first-keypair.pem"
+  not_if "euca-describe-keypairs --region #{node["eucalyptus"]["dns"]["domain"]} my-first-keypair"
   retries 10
   retry_delay 10
 end
 
 execute "Authorizing SSH and ICMP traffic for default security group" do
-  command "euca-authorize -P icmp -t -1:-1 -s 0.0.0.0/0 default && euca-authorize -P tcp -p 22 -s 0.0.0.0/0 default"
+  #command "euca-authorize --region localhost -P icmp -t -1:-1 -s 0.0.0.0/0
+  #default --debug && euca-authorize --region localhost -P tcp -p 22 -s 0.0
+  #.0.0/0 default --debug"
+  command "euca-authorize --region #{node["eucalyptus"]["dns"]["domain"]} -P icmp -t -1:-1 -s 0.0.0.0/0 default --debug && euca-authorize --region #{node["eucalyptus"]["dns"]["domain"]} -P tcp -p 22 -s 0.0.0.0/0 default --debug"
 end
 
 script "install_image" do
@@ -59,20 +62,20 @@ script "install_image" do
   not_if "euca-describe-images | grep default"
   code <<-EOH
   curl #{node['eucalyptus']['default-img-url']} > default.img
-  euca-install-image -i default.img -b default -n default -r x86_64 --virtualization-type hvm
+  euca-install-image --region #{node["eucalyptus"]["dns"]["domain"]} -i default.img -b default -n default -r x86_64 --virtualization-type hvm
   EOH
 end
 
 execute "Ensure default image is public" do
-  command "euca-modify-image-attribute -l -a all $(euca-describe-images | grep default | grep emi | awk '{print $2}')"
+  command "euca-modify-image-attribute --region #{node["eucalyptus"]["dns"]["domain"]} -l -a all $(euca-describe-images | grep default | grep emi | awk '{print $2}')"
 end
 
 execute "Wait for resource availability" do
-  command "euca-describe-availability-zones verbose | grep m1.small | grep -v 0000"
+  command "euca-describe-availability-zones --region #{node["eucalyptus"]["dns"]["domain"]} verbose | grep m1.small | grep -v 0000"
   retries 50
   retry_delay 10
 end
 
 execute "Running an instance" do
-  command "euca-run-instances -k my-first-keypair $(euca-describe-images | grep default | grep emi | cut -f 2)"
+  command "euca-run-instances --region #{node["eucalyptus"]["dns"]["domain"]} -k my-first-keypair $(euca-describe-images --region #{node["eucalyptus"]["dns"]["domain"]} | grep default | grep emi | cut -f 2)"
 end


### PR DESCRIPTION
We will now check for both enabled and broken state while waiting
for objectstorage service.  But for compute/cloudformation we still
want to only wait for enabled state.

Also use $IP.xip.io as the region for faststart.ini and in the turorial
vs. localhost which was conflicting with the euca2ools localhost.ini
so now we should avoid situations where users are reporting errors
in create-first-resources.rb.