### PR TITLE
Add wildcard dns commandline parameter for faststart

### DIFF
--- a/faststart/ciab-template.json
+++ b/faststart/ciab-template.json
@@ -10,7 +10,7 @@
           "authentication.signing_certificates_limit": 10,
           "authentication.credential_download_generate_certificate": "Limited"
       },
-      "dns": {"domain": "IPADDR.xip.io"},
+      "dns": {"domain": "IPADDR.WILDCARD-DNS"},
       "set-bind-addr": true,
       "bind-interface": "BINDINTERFACE",
       "topology": {

--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -7,10 +7,11 @@ OPTIND=1  # Reset in case getopts has been used previously in the shell.
 # Initialize our own variables:
 cookbooks_url="http://euca-chef.s3.amazonaws.com/eucalyptus-cookbooks-4.3.0.tgz"
 nc_install_only=0
+wildcard_dns="xip.io"
 
 function usage
 {
-    echo "usage: cloud-in-a-box.sh [[[-u path-to-cookbooks-tgz ] [--nc]] | [-h]]"
+    echo "usage: cloud-in-a-box.sh [[[-u path-to-cookbooks-tgz ] [--nc] [-s|--wildcard-dns xip.io or nip.io]] | [-h]]"
 }
 
 while [ "$1" != "" ]; do
@@ -19,6 +20,9 @@ while [ "$1" != "" ]; do
                                          cookbooks_url=$1
                                 ;;
         --nc )                  nc_install_only=1
+                                ;;
+        -s | --wildcard-dns )   shift
+                                wildcard_dns=$1
                                 ;;
         -h | --help )           usage
                                 exit
@@ -555,12 +559,17 @@ done
 echo "IPADDR="$ciab_ipaddr
 echo ""
 
-/usr/bin/ping -c 1 $ciab_ipaddr.xip.io 2>&1 >/dev/null
+echo "Using $wildcard_dns for wildcard dns." >>$LOGFILE
+/usr/bin/ping -c 1 $ciab_ipaddr.$wildcard_dns 2>&1 >>$LOGFILE
 if [[ $? != 0 ]]; then
-    echo "Cannot resolve $ciab_ipaddr.xip.io!  We require network
-    connectivity to xip.io for FastStart service DNS resolution.
+    echo "Cannot resolve $ciab_ipaddr.$wildcard_dns!  We require network
+    connectivity to $wildcard_dns for FastStart service DNS resolution.
     Please verify your network connectivity is functioning properly and attempt
     your FastStart install again."
+    echo "Cannot resolve $ciab_ipaddr.$wildcard_dns!  We require network
+    connectivity to $wildcard_dns for FastStart service DNS resolution.
+    Please verify your network connectivity is functioning properly and attempt
+    your FastStart install again." >>$LOGFILE
     exit 1
 fi
 
@@ -736,6 +745,7 @@ sed -i "s/PRIVATEIPS2/$ciab_privateips2/g" $chef_template
 sed -i "s/EXTRASERVICES/$ciab_extraservices/g" $chef_template
 sed -i "s/NIC/$ciab_nic/g" $chef_template
 sed -i "s/NTP/$ciab_ntp/g" $chef_template
+sed -i "s/WILDCARD-DNS/$wildcard_dns/g" $chef_template
 
 if [ "$ciab_bridge_primary" -eq 1 ]; then
     echo ""
@@ -849,7 +859,7 @@ if [ "$nc_install_only" -eq 0 ]; then
   runlistitems="$runlistitems,recipe[eucalyptus::configure]"
 fi
 
-(chef-solo -r cookbooks.tgz -j $chef_template -o $runlistitems 1>>$LOGFILE && echo "Phase 2 success" > faststart-successful-phase2.log) &
+(chef-solo -r cookbooks.tgz -j $chef_template -o "$runlistitems" 1>>$LOGFILE && echo "Phase 2 success" > faststart-successful-phase2.log) &
 coffee $!
 
 if [[ ! -f faststart-successful-phase2.log ]]; then

--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -7,11 +7,11 @@ OPTIND=1  # Reset in case getopts has been used previously in the shell.
 # Initialize our own variables:
 cookbooks_url="http://euca-chef.s3.amazonaws.com/eucalyptus-cookbooks-4.3.0.tgz"
 nc_install_only=0
-wildcard_dns="xip.io"
+wildcard_dns="nip.io"
 
 function usage
 {
-    echo "usage: cloud-in-a-box.sh [[[-u path-to-cookbooks-tgz ] [--nc] [-s|--wildcard-dns xip.io or nip.io]] | [-h]]"
+    echo "usage: cloud-in-a-box.sh [[[-u path-to-cookbooks-tgz ] [--nc]] | [-h]]"
 }
 
 while [ "$1" != "" ]; do
@@ -20,9 +20,6 @@ while [ "$1" != "" ]; do
                                          cookbooks_url=$1
                                 ;;
         --nc )                  nc_install_only=1
-                                ;;
-        -s | --wildcard-dns )   shift
-                                wildcard_dns=$1
                                 ;;
         -h | --help )           usage
                                 exit


### PR DESCRIPTION
This allows users to use xip.io or nip.io for wildcard dns
depending on their preferences. we default to xip.io at the
moment.