### PR TITLE
Run modprobe bridge prior to setting bridge-nf-call-iptables

### DIFF
--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -202,6 +202,7 @@ if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
     notifies :run, "execute[brctl setfd]", :delayed
     notifies :run, "execute[brctl sethello]", :delayed
     notifies :run, "execute[brctl stp]", :delayed
+    notifies :run, "execute[Configure kernel parameters from 70-eucanetd.conf]", :immediately
   end
 else
   execute "Ensure bridge modules loaded into the kernel on NC" do


### PR DESCRIPTION
This will fix the timing inconsistency causing EUCA-12954