### PR TITLE
Run modprobe bridge notification from eucanetd recipe before 70-eucan…

### DIFF
--- a/recipes/eucanetd.rb
+++ b/recipes/eucanetd.rb
@@ -34,6 +34,7 @@ end
 if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
   execute "Configure kernel parameters from 70-eucanetd.conf" do
     command "/usr/lib/systemd/systemd-sysctl 70-eucanetd.conf"
+    notifies :run "execute[Ensure bridge modules loaded into the kernel on NC]", :before
   end
 end
 

--- a/recipes/eucanetd.rb
+++ b/recipes/eucanetd.rb
@@ -34,7 +34,7 @@ end
 if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
   execute "Configure kernel parameters from 70-eucanetd.conf" do
     command "/usr/lib/systemd/systemd-sysctl 70-eucanetd.conf"
-    notifies :run "execute[Ensure bridge modules loaded into the kernel on NC]", :before
+    notifies :run, "execute[Ensure bridge modules loaded into the kernel on NC]", :before
   end
 end
 

--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -202,7 +202,6 @@ if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
     notifies :run, "execute[brctl setfd]", :delayed
     notifies :run, "execute[brctl sethello]", :delayed
     notifies :run, "execute[brctl stp]", :delayed
-    notifies :run, "execute[Configure kernel parameters from 70-eucanetd.conf]", :immediately
   end
 else
   execute "Ensure bridge modules loaded into the kernel on NC" do


### PR DESCRIPTION
…etd.conf

This will invert the behaviour of the last change.  It will run modprobe
bridge notification before the 70-eucanetd.conf sysctl rules are applied.