### PR TITLE
eucanetd is not run on VPCMIDO NCs, skip bridge-nf-call-iptables

### DIFF
--- a/recipes/eucanetd.rb
+++ b/recipes/eucanetd.rb
@@ -32,9 +32,11 @@ if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
   end
 end
 if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
-  execute "Configure kernel parameters from 70-eucanetd.conf" do
-    command "/usr/lib/systemd/systemd-sysctl 70-eucanetd.conf"
-    notifies :run, "execute[Ensure bridge modules loaded into the kernel on NC]", :before
+  if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
+    execute "Configure kernel parameters from 70-eucanetd.conf" do
+      command "/usr/lib/systemd/systemd-sysctl 70-eucanetd.conf"
+      notifies :run, "execute[Ensure bridge modules loaded into the kernel on NC]", :before
+    end
   end
 end
 


### PR DESCRIPTION
Don't run "Ensure bridge modules loaded into the kernel on NC" on
machines running eucanetd recipe in VPC mode.