### PR TITLE
run virsh net-undefine; load br_netfilter on RHEL 7.3

### DIFF
--- a/recipes/eucanetd.rb
+++ b/recipes/eucanetd.rb
@@ -48,7 +48,7 @@ if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
   if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
     execute "Configure kernel parameters from 70-eucanetd.conf" do
       command "/usr/lib/systemd/systemd-sysctl 70-eucanetd.conf"
-      notifies :run, "execute[Ensure bridge and br_netfilter modules loaded into the kernel on NC]", :before
+      notifies :run, "execute[Ensure bridge modules loaded into the kernel on NC]", :before
     end
   end
 end

--- a/recipes/eucanetd.rb
+++ b/recipes/eucanetd.rb
@@ -4,11 +4,24 @@ require 'chef/version_constraint'
 include_recipe "eucalyptus::default"
 
 # Remove default virsh network which runs its own dhcp server
-execute 'virsh net-destroy default' do
-  ignore_failure true
+if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
+  execute 'virsh net-destroy default' do
+    ignore_failure true
+  end
+  execute 'virsh net-autostart default --disable' do
+    ignore_failure true
+  end
 end
-execute 'virsh net-autostart default --disable' do
-  ignore_failure true
+if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
+  execute 'virsh net-destroy default' do
+    ignore_failure true
+  end
+  execute 'virsh net-autostart default --disable' do
+    ignore_failure true
+  end
+  execute 'virsh net-undefine default' do
+    ignore_failure true
+  end
 end
 
 if node["eucalyptus"]["install-type"] == "packages"
@@ -35,7 +48,7 @@ if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
   if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
     execute "Configure kernel parameters from 70-eucanetd.conf" do
       command "/usr/lib/systemd/systemd-sysctl 70-eucanetd.conf"
-      notifies :run, "execute[Ensure bridge modules loaded into the kernel on NC]", :before
+      notifies :run, "execute[Ensure bridge and br_netfilter modules loaded into the kernel on NC]", :before
     end
   end
 end

--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -196,12 +196,22 @@ end
 
 ## use a different notifier to setup bridge in VPCMIDO mode
 if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
-  execute "Ensure bridge modules loaded into the kernel on NC" do
-    command "modprobe bridge"
-    notifies :run, "execute[network-restart]", :immediately
-    notifies :run, "execute[brctl setfd]", :delayed
-    notifies :run, "execute[brctl sethello]", :delayed
-    notifies :run, "execute[brctl stp]", :delayed
+  if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
+    execute "Ensure bridge and br_netfilter modules loaded into the kernel on NC" do
+      command "modprobe bridge; modprobe br_netfilter"
+      notifies :run, "execute[network-restart]", :immediately
+      notifies :run, "execute[brctl setfd]", :delayed
+      notifies :run, "execute[brctl sethello]", :delayed
+      notifies :run, "execute[brctl stp]", :delayed
+    end
+  else
+    execute "Ensure bridge modules loaded into the kernel on NC" do
+      command "modprobe bridge"
+      notifies :run, "execute[network-restart]", :immediately
+      notifies :run, "execute[brctl setfd]", :delayed
+      notifies :run, "execute[brctl sethello]", :delayed
+      notifies :run, "execute[brctl stp]", :delayed
+    end
   end
 else
   execute "Ensure bridge modules loaded into the kernel on NC" do

--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -196,8 +196,8 @@ end
 
 ## use a different notifier to setup bridge in VPCMIDO mode
 if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
-  if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
-    execute "Ensure bridge and br_netfilter modules loaded into the kernel on NC" do
+  if Chef::VersionConstraint.new("~> 7.3").include?(node['platform_version'])
+    execute "Ensure bridge modules loaded into the kernel on NC" do
       command "modprobe bridge; modprobe br_netfilter"
       notifies :run, "execute[network-restart]", :immediately
       notifies :run, "execute[brctl setfd]", :delayed


### PR DESCRIPTION
add virsh net-undefine command to remove default network

modprobe bridge apparently does not load br_netfilter any longer
on RHEL 7.3