### PR TITLE
Stop installing udev files ourselves

### DIFF
--- a/recipes/install-source.rb
+++ b/recipes/install-source.rb
@@ -248,16 +248,6 @@ end
   end
 end
 
-### Add udev rules
-directory '/etc/udev/rules.d'
-directory '/etc/udev/scripts'
-udev_mapping = {'clc/modules/block-storage-common/udev/55-openiscsi.rules' => '/etc/udev/rules.d/55-openiscsi.rules',
-                'clc/modules/block-storage-common/udev/iscsidev.sh' => '/etc/udev/scripts/iscsidev.sh',
-                'clc/modules/block-storage/udev/rules.d/12-dm-permissions.rules' => '/etc/udev/rules.d/12-dm-permissions.rules'}
-udev_mapping.each do |src, dst|
-  execute "cp #{eucalyptus_dir}/#{src} #{dst}"
-end
-
 execute 'run \'modprobe kvm_intel\' to set permissions of /dev/kvm correctly' do
   command 'modprobe kvm_intel'
   only_if { ::File.exist? "/usr/lib/udev/rules.d/80-kvm.rules" }


### PR DESCRIPTION
Eucalyptus 4.4 finally puts udev-related files in the right place out of the box, so this commit simply removes the bits related to that from the cookbook.

At the moment this is breaking direct-from-source builds.  :-(