### PR TITLE
cloud-in-a-box: Add more CIDR/netmask combinations

### DIFF
--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -495,6 +495,14 @@ ciab_netmask_cidr=`ip addr show $active_nic | grep 'inet' | grep -v 'inet6' | aw
 
 if [ "$ciab_netmask_cidr" -eq 16 ]; then
   ciab_netmask_guess="255.255.0.0"
+elif [ "$ciab_netmask_cidr" -eq 20 ]; then
+  ciab_netmask_guess="255.255.240.0"  
+elif [ "$ciab_netmask_cidr" -eq 21 ]; then
+  ciab_netmask_guess="255.255.248.0"
+elif [ "$ciab_netmask_cidr" -eq 22 ]; then
+  ciab_netmask_guess="255.255.252.0"
+elif [ "$ciab_netmask_cidr" -eq 23 ]; then
+  ciab_netmask_guess="255.255.254.0"  
 elif [ "$ciab_netmask_cidr" -eq 24 ]; then
   ciab_netmask_guess="255.255.255.0"
 elif [ "$ciab_netmask_cidr" -eq 25 ]; then


### PR DESCRIPTION
I tried to use cloud-in-a-box with a /22, and was a sad panda that it couldn't figure out the NETMASK I needed.

- Adds CIDR:NETMASK settings for /20-/23 networks