### PR TITLE
4.4 faststart changes; merge missing 4.3 branch updates to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Stories in Ready](https://badge.waffle.io/eucalyptus/eucalyptus-cookbook.png?label=ready&title=Ready)](https://waffle.io/eucalyptus/eucalyptus-cookbook)
 eucalyptus Cookbook
 ===================
-This cookbook installs and configures Eucalyptus on CentOS 6 physical and virtual machines. Source and package installations are supported.
+This cookbook installs and configures Eucalyptus on RHEL/CentOS 7 physical and virtual machines. Source and package installations are supported.
 
 Requirements
 ------------
@@ -15,6 +15,7 @@ The following table descirbes the branch to use for each Eucalyptus release:
 |euca-4.0 | 0.3.x| 4.0.2 |Stable branch for 4.0.x installs |
 |euca-4.1 | 0.4.x | 4.1.1 | Maint branch for 4.1.x installs|
 |euca-4.2 | 1.0.x | 4.2.0 |breaks the attribute API |
+|euca-4.3 | 1.0.x | 4.3.0 |Stable branch for 4.3.x installs |
 
 ### Environment
 To deploy a distributed topology it is necessary to define an environment with at least these attributes defined:
@@ -64,7 +65,7 @@ To deploy a distributed topology it is necessary to define an environment with a
 ```
 
 #### Platforms
-This cookbook only supports RHEL/CentOS 6 at the time being.
+This cookbook only supports RHEL/CentOS 7 at the time being.
 
 #### Berkshelf
 A Berksfile is included to allow users to easily download the required cookbook dependencies.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Once invoked the script does the following:
 
 Inputs from the user are searched and replaced into the templates in `faststart/ciab-template.json` and `fastart/node-template.json` and then used as follows to run the cookbook:
 
-    chef-solo -r cookbooks.tgz -j ciab.json
+    chef-client -z -r cookbooks.tgz -j ciab.json
 
 ### Releasing
 In order to release a new version of Faststart, you must first package up the current cookbook versions with Berkshelf.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,7 +55,7 @@ default["eucalyptus"]["bind-network"] = ""
 default["eucalyptus"]["log-level"] = "INFO"
 default["eucalyptus"]["user"] = "eucalyptus"
 default["eucalyptus"]["cloud-opts"] = ""
-default['eucalyptus']['dns']['domain'] = ""
+default['eucalyptus']['dns-domain'] = nil
 ### Topology must be set for key sync to work
 default['eucalyptus']['sync-keys'] = true
 default["eucalyptus"]["local-cluster-name"] = "default"

--- a/faststart/ciab-template.json
+++ b/faststart/ciab-template.json
@@ -11,7 +11,7 @@
           "authentication.signing_certificates_limit": 10,
           "authentication.credential_download_generate_certificate": "Limited"
       },
-      "dns": {"domain": "IPADDR.WILDCARD-DNS"},
+      "dns-domain": "IPADDR.WILDCARD-DNS",
       "set-bind-addr": true,
       "bind-interface": "BINDINTERFACE",
       "topology": {

--- a/faststart/ciab-template.json
+++ b/faststart/ciab-template.json
@@ -2,7 +2,7 @@
     "eucalyptus": {
       "yum-options": "--nogpg",
       "cloud-properties": {},
-      "eucalyptus-repo": "http://downloads-cdn0.eucalyptus.com/software/eucalyptus/4.3/rhel/7/x86_64/",
+      "eucalyptus-repo": "http://downloads.eucalyptus.com/software/eucalyptus/nightly/4.4/rhel/7/x86_64/",
       "euca2ools-repo": "http://downloads-cdn0.eucalyptus.com/software/euca2ools/3.3/rhel/7/x86_64/",
       "install-service-image": EXTRASERVICES,
       "ntp-server": "NTP",
@@ -15,7 +15,7 @@
       "set-bind-addr": true,
       "bind-interface": "BINDINTERFACE",
       "topology": {
-        "clc-1": "IPADDR",
+        "clc": ["IPADDR"],
         "user-facing": ["IPADDR"],
         "clusters": {
           "default": {
@@ -30,6 +30,7 @@
           "walrusbackend": ["IPADDR"]
           }
       },
+      "sync-keys": true,
       "network": {
         "mode": "EDGE",
         "public-interface": "br0",
@@ -48,7 +49,7 @@
               "Netmask": "NETMASK",
               "Gateway": "GATEWAY"
             },
-            "PrivateIps": [ "PRIVATEIPS1-PRIVATEIPS2"]
+            "PrivateIps": ["PRIVATEIPS1-PRIVATEIPS2"]
           }
         ]
       }

--- a/faststart/ciab-template.json
+++ b/faststart/ciab-template.json
@@ -1,8 +1,8 @@
 {
     "eucalyptus": {
       "yum-options": "--nogpg",
-      "eucalyptus-repo": "http://builds.qa1.eucalyptus-systems.com/packages/tags/eucalyptus-devel/rhel/$releasever/$basearch/",
-      "euca2ools-repo": "http://downloads.eucalyptus.com/software/euca2ools/3.3/centos/7/x86_64/",
+      "eucalyptus-repo": "http://downloads-cdn0.eucalyptus.com/software/eucalyptus/4.3/rhel/7/x86_64/",
+      "euca2ools-repo": "http://downloads-cdn0.eucalyptus.com/software/euca2ools/3.3/rhel/7/x86_64/",
       "install-service-image": EXTRASERVICES,
       "ntp-server": "NTP",
       "system-properties": {

--- a/faststart/ciab-template.json
+++ b/faststart/ciab-template.json
@@ -1,6 +1,7 @@
 {
     "eucalyptus": {
       "yum-options": "--nogpg",
+      "cloud-properties": {},
       "eucalyptus-repo": "http://downloads-cdn0.eucalyptus.com/software/eucalyptus/4.3/rhel/7/x86_64/",
       "euca2ools-repo": "http://downloads-cdn0.eucalyptus.com/software/euca2ools/3.3/rhel/7/x86_64/",
       "install-service-image": EXTRASERVICES,
@@ -15,16 +16,19 @@
       "bind-interface": "BINDINTERFACE",
       "topology": {
         "clc-1": "IPADDR",
-        "walrus": "IPADDR",
         "user-facing": ["IPADDR"],
         "clusters": {
           "default": {
-            "cc-1": "IPADDR",
-            "sc-1": "IPADDR",
-            "nodes": "IPADDR",
+            "cc": ["IPADDR"],
+            "sc": ["IPADDR"],
+            "nodes": ["IPADDR"],
             "storage-backend": "overlay"
           }
-        }
+        },
+        "objectstorage": {
+          "providerclient": "walrus",
+          "walrusbackend": ["IPADDR"]
+          }
       },
       "network": {
         "mode": "EDGE",
@@ -34,21 +38,19 @@
         "bridge-ip": "IPADDR",
         "bridge-netmask": "NETMASK",
         "bridge-gateway": "GATEWAY",
-        "config-json": {
-          "InstanceDnsServers": ["IPADDR"],
-          "PublicIps": ["PUBLICIPS1-PUBLICIPS2"],
-          "Clusters": [
-            {
-              "Name": "default",
-              "Subnet": {
-                "Subnet": "SUBNET",
-                "Netmask": "NETMASK",
-                "Gateway": "GATEWAY"
-              },
-              "PrivateIps": [ "PRIVATEIPS1-PRIVATEIPS2"]
-            }
-          ]
-        }
+        "InstanceDnsServers": ["IPADDR"],
+        "PublicIps": ["PUBLICIPS1-PUBLICIPS2"],
+        "clusters": [
+          {
+            "Name": "default",
+            "Subnet": {
+              "Subnet": "SUBNET",
+              "Netmask": "NETMASK",
+              "Gateway": "GATEWAY"
+            },
+            "PrivateIps": [ "PRIVATEIPS1-PRIVATEIPS2"]
+          }
+        ]
       }
     }
 }

--- a/faststart/ciab-template.json
+++ b/faststart/ciab-template.json
@@ -10,7 +10,7 @@
           "authentication.signing_certificates_limit": 10,
           "authentication.credential_download_generate_certificate": "Limited"
       },
-      "dns": {"domain": "IPADDR.xip.io"},
+      "dns": {"domain": "IPADDR.WILDCARD-DNS"},
       "set-bind-addr": true,
       "bind-interface": "BINDINTERFACE",
       "topology": {

--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -5,7 +5,7 @@
 OPTIND=1  # Reset in case getopts has been used previously in the shell.
 
 # Initialize our own variables:
-cookbooks_url="http://euca-chef.s3.amazonaws.com/eucalyptus-cookbooks-4.2.0.tgz"
+cookbooks_url="http://euca-chef.s3.amazonaws.com/eucalyptus-cookbooks-4.3.0.tgz"
 nc_install_only=0
 
 function usage

--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -5,7 +5,7 @@
 OPTIND=1  # Reset in case getopts has been used previously in the shell.
 
 # Initialize our own variables:
-cookbooks_url="http://euca-chef.s3.amazonaws.com/eucalyptus-cookbooks-4.3.0.tgz"
+cookbooks_url="http://euca-chef.s3.amazonaws.com/eucalyptus-cookbooks-4.3.1.tgz"
 nc_install_only=0
 wildcard_dns="nip.io"
 
@@ -303,12 +303,12 @@ fi
 
 # Check to see that we're running on CentOS or RHEL and the right version.
 echo "[Precheck] Checking OS"
-cat /etc/redhat-release | egrep 'release.*7.[2]' 1>>$LOGFILE
+cat /etc/redhat-release | egrep 'release.*7.[23]' 1>>$LOGFILE
 if [ "$?" != "0" ]; then
     echo "======"
     echo "[FATAL] Operating system not supported"
     echo ""
-    echo "Please note: Eucalyptus Faststart only runs on RHEL or CentOS 7.2"
+    echo "Please note: Eucalyptus Faststart only runs on RHEL or CentOS 7.2 or 7.3"
     echo "To try Faststart on another platform, consider trying Eucadev:"
     echo "https://github.com/eucalyptus/eucalyptus-cookbook/blob/master/eucadev.md"
     echo ""

--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -555,6 +555,15 @@ done
 echo "IPADDR="$ciab_ipaddr
 echo ""
 
+/usr/bin/dig $ciab_ipaddr.xip.io 2>&1 >/dev/null
+if [[ $? != 0 ]]; then
+    echo "Cannot resolve $ciab_ipaddr.xip.io!  We require network
+    connectivity to xip.io for FastStart service DNS resolution.
+    Please verify your network connectivity is functioning properly and attempt
+    your FastStart install again."
+    exit 1
+fi
+
 echo "What's the gateway for this host? ($ciab_gateway_guess)"
 until valid_ip $ciab_gateway; do
     read ciab_gateway

--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -677,10 +677,10 @@ fi
 #
 ###############################################################################
 
-# Check to see if chef-solo is installed
+# Check to see if chef-client is installed
 echo "[Chef] Checking if Chef Client is installed"
 CHEF_VERSION="12.8.1"
-which chef-solo
+which chef-client
 if [ "$?" != "0" ]; then
     echo "====="
     echo "[INFO] Chef not found. Installing Chef Client"
@@ -822,7 +822,7 @@ if [ "$nc_install_only" -eq 0 ]; then
 fi
 
 # Execute phase 1 which adds only the cloud-controller recipe to the run_list
-(chef-solo -r cookbooks.tgz -j $chef_template -o $runlistitems 1>>$LOGFILE && echo "Phase 1 success" > faststart-successful-phase1.log) &
+(chef-client -z -r cookbooks.tgz -j $chef_template -o $runlistitems 1>>$LOGFILE && echo "Phase 1 success" > faststart-successful-phase1.log) &
 coffee $!
 
 if [[ ! -f faststart-successful-phase1.log ]]; then
@@ -856,7 +856,7 @@ if [ "$nc_install_only" -eq 0 ]; then
   runlistitems="$runlistitems,recipe[eucalyptus::configure]"
 fi
 
-(chef-solo -r cookbooks.tgz -j $chef_template -o "$runlistitems" 1>>$LOGFILE && echo "Phase 2 success" > faststart-successful-phase2.log) &
+(chef-client -z -r cookbooks.tgz -j $chef_template -o "$runlistitems" 1>>$LOGFILE && echo "Phase 2 success" > faststart-successful-phase2.log) &
 coffee $!
 
 if [[ ! -f faststart-successful-phase2.log ]]; then
@@ -884,7 +884,7 @@ if [ "$nc_install_only" -eq 0 ]; then
   runlistitems="recipe[eucalyptus::create-first-resources]"
 fi
 
-(chef-solo -r cookbooks.tgz -j $chef_template -o $runlistitems 1>>$LOGFILE && echo "Phase 3 success" > faststart-successful-phase3.log) &
+(chef-client -z -r cookbooks.tgz -j $chef_template -o $runlistitems 1>>$LOGFILE && echo "Phase 3 success" > faststart-successful-phase3.log) &
 coffee $!
 
 if [[ ! -f faststart-successful-phase3.log ]]; then

--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -7,10 +7,11 @@ OPTIND=1  # Reset in case getopts has been used previously in the shell.
 # Initialize our own variables:
 cookbooks_url="http://euca-chef.s3.amazonaws.com/eucalyptus-cookbooks-4.3.0.tgz"
 nc_install_only=0
+wildcard_dns="xip.io"
 
 function usage
 {
-    echo "usage: cloud-in-a-box.sh [[[-u path-to-cookbooks-tgz ] [--nc]] | [-h]]"
+    echo "usage: cloud-in-a-box.sh [[[-u path-to-cookbooks-tgz ] [--nc] [-s|--wildcard-dns xip.io or nip.io]] | [-h]]"
 }
 
 while [ "$1" != "" ]; do
@@ -19,6 +20,9 @@ while [ "$1" != "" ]; do
                                          cookbooks_url=$1
                                 ;;
         --nc )                  nc_install_only=1
+                                ;;
+        -s | --wildcard-dns )   shift
+                                wildcard_dns=$1
                                 ;;
         -h | --help )           usage
                                 exit
@@ -555,12 +559,17 @@ done
 echo "IPADDR="$ciab_ipaddr
 echo ""
 
-/usr/bin/ping -c 1 $ciab_ipaddr.xip.io 2>&1 >/dev/null
+echo "Using $wildcard_dns for wildcard dns." >>$LOGFILE
+/usr/bin/ping -c 1 $ciab_ipaddr.$wildcard_dns 2>&1 >>$LOGFILE
 if [[ $? != 0 ]]; then
-    echo "Cannot resolve $ciab_ipaddr.xip.io!  We require network
-    connectivity to xip.io for FastStart service DNS resolution.
+    echo "Cannot resolve $ciab_ipaddr.$wildcard_dns!  We require network
+    connectivity to $wildcard_dns for FastStart service DNS resolution.
     Please verify your network connectivity is functioning properly and attempt
     your FastStart install again."
+    echo "Cannot resolve $ciab_ipaddr.$wildcard_dns!  We require network
+    connectivity to $wildcard_dns for FastStart service DNS resolution.
+    Please verify your network connectivity is functioning properly and attempt
+    your FastStart install again." >>$LOGFILE
     exit 1
 fi
 
@@ -736,6 +745,7 @@ sed -i "s/PRIVATEIPS2/$ciab_privateips2/g" $chef_template
 sed -i "s/EXTRASERVICES/$ciab_extraservices/g" $chef_template
 sed -i "s/NIC/$ciab_nic/g" $chef_template
 sed -i "s/NTP/$ciab_ntp/g" $chef_template
+sed -i "s/WILDCARD-DNS/$wildcard_dns/g" $chef_template
 
 if [ "$ciab_bridge_primary" -eq 1 ]; then
     echo ""
@@ -849,7 +859,7 @@ if [ "$nc_install_only" -eq 0 ]; then
   runlistitems="$runlistitems,recipe[eucalyptus::configure]"
 fi
 
-(chef-solo -r cookbooks.tgz -j $chef_template -o $runlistitems 1>>$LOGFILE && echo "Phase 2 success" > faststart-successful-phase2.log) &
+(chef-solo -r cookbooks.tgz -j $chef_template -o "$runlistitems" 1>>$LOGFILE && echo "Phase 2 success" > faststart-successful-phase2.log) &
 coffee $!
 
 if [[ ! -f faststart-successful-phase2.log ]]; then

--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -555,7 +555,7 @@ done
 echo "IPADDR="$ciab_ipaddr
 echo ""
 
-/usr/bin/dig $ciab_ipaddr.xip.io 2>&1 >/dev/null
+/usr/bin/ping -c 1 $ciab_ipaddr.xip.io 2>&1 >/dev/null
 if [[ $? != 0 ]]; then
     echo "Cannot resolve $ciab_ipaddr.xip.io!  We require network
     connectivity to xip.io for FastStart service DNS resolution.

--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -7,11 +7,11 @@ OPTIND=1  # Reset in case getopts has been used previously in the shell.
 # Initialize our own variables:
 cookbooks_url="http://euca-chef.s3.amazonaws.com/eucalyptus-cookbooks-4.3.0.tgz"
 nc_install_only=0
-wildcard_dns="xip.io"
+wildcard_dns="nip.io"
 
 function usage
 {
-    echo "usage: cloud-in-a-box.sh [[[-u path-to-cookbooks-tgz ] [--nc] [-s|--wildcard-dns xip.io or nip.io]] | [-h]]"
+    echo "usage: cloud-in-a-box.sh [[[-u path-to-cookbooks-tgz ] [--nc]] | [-h]]"
 }
 
 while [ "$1" != "" ]; do
@@ -20,9 +20,6 @@ while [ "$1" != "" ]; do
                                          cookbooks_url=$1
                                 ;;
         --nc )                  nc_install_only=1
-                                ;;
-        -s | --wildcard-dns )   shift
-                                wildcard_dns=$1
                                 ;;
         -h | --help )           usage
                                 exit

--- a/faststart/node-template.json
+++ b/faststart/node-template.json
@@ -1,8 +1,8 @@
 {
     "eucalyptus": {
       "yum-options": "--nogpg",
-      "eucalyptus-repo": "http://builds.qa1.eucalyptus-systems.com/packages/tags/eucalyptus-devel/rhel/$releasever/$basearch/",
-      "euca2ools-repo": "http://downloads.eucalyptus.com/software/euca2ools/3.3/centos/7/x86_64/",
+      "eucalyptus-repo": "http://downloads-cdn0.eucalyptus.com/software/eucalyptus/4.3/rhel/7/x86_64/",
+      "euca2ools-repo": "http://downloads-cdn0.eucalyptus.com/software/euca2ools/3.3/rhel/7/x86_64/",
       "ntp-server": "NTP",
       "network": {
         "mode": "EDGE",

--- a/faststart/tutorials/describe-images.sh
+++ b/faststart/tutorials/describe-images.sh
@@ -3,6 +3,16 @@
 bold=`tput bold`
 normal=`tput sgr0`
 
+region=`grep domain ../../../../ciab.json | egrep -o '([0-9]{1,3}\.){3}[0-9]{1,3}.xip.io'`
+if [ "${region}" = "" ]
+then
+    echo "ERROR: Cannot determine region from file ../../../../ciab.json"
+    echo "Please verify that this tutorial is being run in the directory "
+    echo "/root/cookbooks/eucalyptus/faststart/tutorials where we expect it to"
+    echo "be run."
+    exit 1
+fi
+
 echo ""
 echo ""
 echo "${bold}Listing Images${normal}"
@@ -35,9 +45,9 @@ echo "configuration file up for you. Once this has been"
 echo "set up, with each euca2ools command, the"
 echo "\"--region\" option must be used. For FastStart,"
 echo "the region option will contain the value"
-echo "\"admin@localhost\".  For example:"
+echo "\"admin@${region}\".  For example:"
 echo ""
-echo "${bold}euca-describe-availability-zones --region admin@localhost${normal}"
+echo "${bold}euca-describe-availability-zones --region admin@${region}${normal}"
 echo ""
 echo "To learn more about using euca2ools configuration file, please refer to"
 echo "the Euca2ools Guide section entitled \"Working with Euca2ools Configuration Files\":"
@@ -49,17 +59,17 @@ echo "The euca2ools command for listing images is ${bold}euca-describe-images${n
 echo "If you have ever worked with Amazon Web Services, you will"
 echo "notice that the command, and the output from the command, is"
 echo "nearly identical to the comparable AWS command; this is by design."
-echo "Press Enter to run ${bold}euca-describe-images --region admin@localhost${normal} now."
+echo "Press Enter to run ${bold}euca-describe-images --region admin@${region}${normal} now."
 
 read continue
 
-echo "${bold}+ euca-describe-images --region admin@localhost"
-euca-describe-images --region admin@localhost
+echo "${bold}+ euca-describe-images --region admin@${region}"
+euca-describe-images --region admin@${region}
 echo "${normal}"
 
 echo "Now let's review some of the key output of that command:"
 echo ""
-imagelist=`euca-describe-images --region admin@localhost| tail -n 1`
+imagelist=`euca-describe-images --region admin@${region}| tail -n 1`
 imageid=`echo $imagelist | awk '{print $2}'`
 imagepath=`echo $imagelist | awk '{print $3}'`
 public=`echo $imagelist | awk '{print $6}'`

--- a/faststart/tutorials/install-image.sh
+++ b/faststart/tutorials/install-image.sh
@@ -7,6 +7,16 @@
 bold=`tput bold`
 normal=`tput sgr0`
 
+region=`grep domain ../../../../ciab.json | egrep -o '([0-9]{1,3}\.){3}[0-9]{1,3}.xip.io'`
+if [ "${region}" = "" ]
+then
+    echo "ERROR: Cannot determine region from file ../../../../ciab.json"
+    echo "Please verify that this tutorial is being run in the directory "
+    echo "/root/cookbooks/eucalyptus/faststart/tutorials where we expect it to"
+    echo "be run."
+    exit 1
+fi
+
 echo ""
 echo ""
 echo "${bold}Installing Images${normal}"
@@ -76,7 +86,7 @@ echo ""
 echo "OK, now you are ready to install the image into your cloud."
 echo "To install the image, we will run the following command:"
 echo ""
-echo "${bold}euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm --region admin@localhost${normal}"
+echo "${bold}euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm --region admin@${region}${normal}"
 echo ""
 echo "  ${bold}-n Fedora20${normal} specifies the name we're giving the image."
 echo "  ${bold}-b tutorial${normal} specifies the bucket we're putting the image into."
@@ -89,8 +99,8 @@ echo "Hit Enter to install the image."
 read continue
 
 # Install the image.
-echo "+ ${bold}euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm --region admin@localhost${normal}"
-euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm --region admin@localhost
+echo "+ ${bold}euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm --region admin@${region}${normal}"
+euca-install-image -n Fedora20 -b tutorial -i fedora.raw -r x86_64 --virtualization-type hvm --region admin@${region}
 if [ "$?" != "0" ]; then
     echo "======"
     echo "[OOPS] euca-install-image failed!"
@@ -113,9 +123,9 @@ echo "Hit Enter to modify the image attribute."
 read continue
 
 # get the EMI_ID
-EMI_ID=$(euca-describe-images --region admin@localhost | grep tutorial | tail -n 1 | grep emi | cut -f 2)
-echo "+ ${bold}euca-modify-image-attribute -l -a all $EMI_ID --region admin@localhost${normal}"
-euca-modify-image-attribute -l -a all $EMI_ID --region admin@localhost
+EMI_ID=$(euca-describe-images --region admin@${region} | grep tutorial | tail -n 1 | grep emi | cut -f 2)
+echo "+ ${bold}euca-modify-image-attribute -l -a all $EMI_ID --region admin@${region}${normal}"
+euca-modify-image-attribute -l -a all $EMI_ID --region admin@${region}
 
 echo ""
 echo "Your new Fedora machine image is installed and available to all"
@@ -126,8 +136,8 @@ echo "Hit Enter to show the list of images."
 
 read continue
 
-echo "+ ${bold}euca-describe-images --region admin@localhost${normal}"
-euca-describe-images --region admin@localhost
+echo "+ ${bold}euca-describe-images --region admin@${region}${normal}"
+euca-describe-images --region admin@${region}
 
 echo ""
 

--- a/faststart/tutorials/launch-instances.sh
+++ b/faststart/tutorials/launch-instances.sh
@@ -3,6 +3,16 @@
 bold=`tput bold`
 normal=`tput sgr0`
 
+region=`grep domain ../../../../ciab.json | egrep -o '([0-9]{1,3}\.){3}[0-9]{1,3}.xip.io'`
+if [ "${region}" = "" ]
+then
+    echo "ERROR: Cannot determine region from file ../../../../ciab.json"
+    echo "Please verify that this tutorial is being run in the directory "
+    echo "/root/cookbooks/eucalyptus/faststart/tutorials where we expect it to"
+    echo "be run."
+    exit 1
+fi
+
 echo ""
 echo ""
 echo "${bold}Launching Instances${normal}"
@@ -18,7 +28,7 @@ then
 fi
 
 # Be sure the tutorial image is installed
-EMI_ID=$(euca-describe-images --region admin@localhost | grep tutorial | grep emi | tail -n 1 | cut -f 2)
+EMI_ID=$(euca-describe-images --region admin@${region} | grep tutorial | grep emi | tail -n 1 | cut -f 2)
 echo $EMI_ID
 if [ "$EMI_ID" == "" ]
 then
@@ -29,14 +39,14 @@ then
    exit 1
 fi
 
-echo "${bold}euca-run-instances -k my-first-keypair $EMI_ID --region admin@localhost${normal}"
-euca-run-instances -k my-first-keypair $EMI_ID --region admin@localhost
+echo "${bold}euca-run-instances -k my-first-keypair $EMI_ID --region admin@${region}${normal}"
+euca-run-instances -k my-first-keypair $EMI_ID --region admin@${region}
 
 # Capture the instance ID and public address
 echo "Capturing the instance ID"
-INSTANCE_ID=$(euca-describe-instances --region admin@localhost | grep $EMI_ID | grep -v terminated | cut -f2)
+INSTANCE_ID=$(euca-describe-instances --region admin@${region} | grep $EMI_ID | grep -v terminated | cut -f2)
 echo "Capturing the public ip address"
-INSTANCE_ADDR=$(euca-describe-instances --region admin@localhost | grep $INSTANCE_ID | cut -f4)
+INSTANCE_ADDR=$(euca-describe-instances --region admin@${region} | grep $INSTANCE_ID | cut -f4)
 
 
 # Wait up to 30 seconds for the instance to start.
@@ -46,7 +56,7 @@ STATUS=
 while [ $TIMER -le 5 ]
 do
    sleep 5
-   STATUS=$(euca-describe-instances $INSTANCE_ID --region admin@localhost | grep $EMI_ID | grep running)
+   STATUS=$(euca-describe-instances $INSTANCE_ID --region admin@${region} | grep $EMI_ID | grep running)
    [ "$STATUS" != "" ] && break;
    TIMER=$(( $TIMER + 1 ))
    echo $TIMER

--- a/faststart/tutorials/master-tutorial.sh
+++ b/faststart/tutorials/master-tutorial.sh
@@ -3,6 +3,16 @@
 bold=`tput bold`
 normal=`tput sgr0`
 
+region=`grep domain ../../../../ciab.json | egrep -o '([0-9]{1,3}\.){3}[0-9]{1,3}.xip.io'`
+if [ "${region}" = "" ]
+then
+    echo "ERROR: Cannot determine region from file ../../../../ciab.json"
+    echo "Please verify that this tutorial is being run in the directory "
+    echo "/root/cookbooks/eucalyptus/faststart/tutorials where we expect it to"
+    echo "be run."
+    exit 1
+fi
+
 echo ""
 echo "*****"
 echo ""

--- a/libraries/key-sync.rb
+++ b/libraries/key-sync.rb
@@ -28,6 +28,7 @@ module Eucalyptus
       %w(cloud-cert.pem cloud-pk.pem euca.p12).each do |key_name|
         cert = Base64.encode64(::File.new("#{cloud_keys_dir}/#{key_name}").read)
         node.set['eucalyptus']['cloud-keys'][key_name] = cert
+        node.save
       end
     end
 

--- a/libraries/key-sync.rb
+++ b/libraries/key-sync.rb
@@ -28,7 +28,6 @@ module Eucalyptus
       %w(cloud-cert.pem cloud-pk.pem euca.p12).each do |key_name|
         cert = Base64.encode64(::File.new("#{cloud_keys_dir}/#{key_name}").read)
         node.set['eucalyptus']['cloud-keys'][key_name] = cert
-        node.save
       end
     end
 

--- a/recipes/cloud-service.rb
+++ b/recipes/cloud-service.rb
@@ -29,7 +29,10 @@ if node["eucalyptus"]["set-bind-addr"]
     # Use default gw interface IP
     bind_addr = node["ipaddress"]
   end
-  node.override['eucalyptus']['cloud-opts'] = node['eucalyptus']['cloud-opts'] + " --bind-addr=" + bind_addr
+  if not node['eucalyptus']['cloud-opts'].include?"--bind-addr="
+    Chef::Log.info "Adding --bind-addr to eucalyptus.conf cloud-opts"
+    node.override['eucalyptus']['cloud-opts'] = node['eucalyptus']['cloud-opts'] + " --bind-addr=" + bind_addr
+  end
 end
 
 

--- a/recipes/cluster-controller.rb
+++ b/recipes/cluster-controller.rb
@@ -55,12 +55,13 @@ end
 cluster_name = Eucalyptus::KeySync.get_local_cluster_name(node)
 
 node.set["eucalyptus"]["nodes"] = node["eucalyptus"]["topology"]["clusters"][cluster_name]["nodes"]
+node.save
 
 ruby_block "Sync keys for CC" do
   block do
     Eucalyptus::KeySync.get_cluster_keys(node, "cc")
   end
-  only_if { not Chef::Config[:solo] and node['eucalyptus']['sync-keys'] }
+  only_if { node['eucalyptus']['sync-keys'] }
 end
 
 execute "Ensure bridge modules loaded into the kernel on CC" do

--- a/recipes/cluster-controller.rb
+++ b/recipes/cluster-controller.rb
@@ -55,11 +55,10 @@ end
 cluster_name = Eucalyptus::KeySync.get_local_cluster_name(node)
 
 node.set["eucalyptus"]["nodes"] = node["eucalyptus"]["topology"]["clusters"][cluster_name]["nodes"]
-node.save
 
 ruby_block "Sync keys for CC" do
   block do
-    Eucalyptus::KeySync.get_cluster_keys(node, "cc-1")
+    Eucalyptus::KeySync.get_cluster_keys(node, "cc")
   end
   only_if { not Chef::Config[:solo] and node['eucalyptus']['sync-keys'] }
 end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -205,10 +205,30 @@ if Eucalyptus::Enterprise.is_enterprise?(node)
 end
 
 %w{objectstorage compute cloudformation}.each do |service|
-  execute "Wait for enabled #{service}" do
-    command "#{describe_services} --filter service-type=#{service} | grep enabled"
-    retries 15
-    retry_delay 20
+  ruby_block "Block until #{service} ready" do
+    block do
+        # stole loop from:
+        # https://github.com/chef-cookbooks/aws/blob/bd40e6c668e3975a1bbb1e82361c462db646c221/providers/elastic_ip.rb#L70-L89
+        begin
+            # Timeout.timeout() apparently can't take the #{} chef
+            # variable construct so use ruby @ instance variable instead
+            @seconds = node['eucalyptus']['configure-service-timeout']
+            Timeout.timeout(@seconds) do
+                Chef::Log.info "Setting a #{node['eucalyptus']['configure-service-timeout']} second timeout and waiting for #{service} to be ready."
+                loop do
+                    if EucalyptusHelper.getservicestates?("#{service}",["enabled", "broken"])
+                        Chef::Log.info "#{service} service ready, continuing..."
+                        break
+                    else
+                        Chef::Log.info "#{service} service state not ready, sleeping 5 seconds."
+                    end
+                    sleep 5
+                end
+            end
+            rescue Timeout::Error
+                raise "Timed out waiting for #{service} to be ready after #{node['eucalyptus']['configure-service-timeout']} seconds"
+            end
+    end
   end
 end
 

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -216,7 +216,7 @@ end
             Timeout.timeout(@seconds) do
                 Chef::Log.info "Setting a #{node['eucalyptus']['configure-service-timeout']} second timeout and waiting for #{service} to be ready."
                 loop do
-                    if EucalyptusHelper.getservicestates?("#{service}",["enabled", "broken"])
+                    if EucalyptusHelper.getservicestates?("#{service}",["enabled"])
                         Chef::Log.info "#{service} service ready, continuing..."
                         break
                     else

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -391,8 +391,8 @@ ruby_block "Install Service Image" do
       osg_urls.push("http://#{ufs}:8773/services/objectstorage/")
     end
 
-    if node['eucalyptus']['dns']['domain']
-      osg_urls.push("http://s3.#{node["eucalyptus"]["dns"]["domain"]}:8773/")
+    if node['eucalyptus']['dns-domain']
+      osg_urls.push("http://s3.#{node["eucalyptus"]["dns-domain"]}:8773/")
     end
     osg_urls.each do |osg_url|
       Chef::Log.info "Attempting to install service image using s3 url: #{osg_url}"
@@ -411,7 +411,7 @@ ruby_block "Install Service Image" do
       if service_image[:is_configured]
         break
       else
-        ec2_url = "http://ec2.#{node["eucalyptus"]["dns"]["domain"]}:8773/"
+        ec2_url = "http://ec2.#{node["eucalyptus"]["dns-domain"]}:8773/"
         Chef::Log.info "running service image installation command: #{as_admin} S3_URL=#{osg_url} esi-install-image --ec2_url #{ec2_url} --region localhost --install-default"
         cmd = Mixlib::ShellOut.new("#{as_admin} S3_URL=#{osg_url} esi-install-image --ec2_url #{ec2_url} --region localhost --install-default")
         cmd.run_command

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -24,14 +24,14 @@ command_prefix = "#{as_admin} #{node['eucalyptus']['home-directory']}"
 describe_services = "#{command_prefix}/usr/bin/euserv-describe-services"
 euctl = "#{command_prefix}/usr/bin/euctl"
 
-if node['eucalyptus']['dns']['domain']
+if !node['eucalyptus']['dns-domain'].nil? && !node['eucalyptus']['dns-domain'].empty?
   execute "Enable DNS delegation" do
     command "#{euctl} bootstrap.webservices.use_dns_delegation=true"
     retries 15
     retry_delay 20
   end
-  execute "Set DNS domain to #{node['eucalyptus']['dns']['domain']}" do
-    command "#{euctl} system.dns.dnsdomain=#{node['eucalyptus']['dns']['domain']}"
+  execute "Set DNS domain to #{node['eucalyptus']['dns-domain']}" do
+    command "#{euctl} system.dns.dnsdomain=#{node['eucalyptus']['dns-domain']}"
     retries 15
     retry_delay 20
   end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -204,7 +204,35 @@ if Eucalyptus::Enterprise.is_enterprise?(node)
   end
 end
 
-%w{objectstorage compute cloudformation}.each do |service|
+%w{objectstorage}.each do |service|
+  ruby_block "Block until #{service} ready" do
+    block do
+        # stole loop from:
+        # https://github.com/chef-cookbooks/aws/blob/bd40e6c668e3975a1bbb1e82361c462db646c221/providers/elastic_ip.rb#L70-L89
+        begin
+            # Timeout.timeout() apparently can't take the #{} chef
+            # variable construct so use ruby @ instance variable instead
+            @seconds = node['eucalyptus']['configure-service-timeout']
+            Timeout.timeout(@seconds) do
+                Chef::Log.info "Setting a #{node['eucalyptus']['configure-service-timeout']} second timeout and waiting for #{service} to be ready."
+                loop do
+                    if EucalyptusHelper.getservicestates?("#{service}",["enabled", "broken"])
+                        Chef::Log.info "#{service} service ready, continuing..."
+                        break
+                    else
+                        Chef::Log.info "#{service} service state not ready, sleeping 5 seconds."
+                    end
+                    sleep 5
+                end
+            end
+            rescue Timeout::Error
+                raise "Timed out waiting for #{service} to be ready after #{node['eucalyptus']['configure-service-timeout']} seconds"
+            end
+    end
+  end
+end
+
+%w{compute cloudformation}.each do |service|
   ruby_block "Block until #{service} ready" do
     block do
         # stole loop from:

--- a/recipes/create-first-resources.rb
+++ b/recipes/create-first-resources.rb
@@ -27,7 +27,7 @@ faststart_ini = "/root/.euca/faststart.ini"
 directory '/root/.euca'
 
 execute "Create admin credentials" do
-  command "#{as_admin} euare-useraddkey admin -wld #{node["eucalyptus"]["dns"]["domain"]} -w > #{faststart_ini} --region #{node["eucalyptus"]["dns"]["domain"]}"
+  command "#{as_admin} euare-useraddkey admin -wld #{node["eucalyptus"]["dns-domain"]} -w > #{faststart_ini} --region #{node["eucalyptus"]["dns-domain"]}"
   creates faststart_ini
   not_if { ::File.exist? "#{faststart_ini}" }
 end
@@ -36,20 +36,20 @@ bash "Set default region" do
    user "root"
    code <<-EOF
       echo '[global]' >> #{faststart_ini}
-      echo 'default-region = #{node["eucalyptus"]["dns"]["domain"]}' >> #{faststart_ini}
+      echo 'default-region = #{node["eucalyptus"]["dns-domain"]}' >> #{faststart_ini}
    EOF
    not_if "grep -q default-region #{faststart_ini}"
 end
 
 execute "Add keypair: my-first-keypair" do
-  command "euca-create-keypair --region #{node["eucalyptus"]["dns"]["domain"]} my-first-keypair >/root/my-first-keypair.pem && chmod 0600 /root/my-first-keypair.pem"
-  not_if "euca-describe-keypairs --region #{node["eucalyptus"]["dns"]["domain"]} my-first-keypair"
+  command "euca-create-keypair --region #{node["eucalyptus"]["dns-domain"]} my-first-keypair >/root/my-first-keypair.pem && chmod 0600 /root/my-first-keypair.pem"
+  not_if "euca-describe-keypairs --region #{node["eucalyptus"]["dns-domain"]} my-first-keypair"
   retries 10
   retry_delay 10
 end
 
 execute "Authorizing SSH and ICMP traffic for default security group" do
-  command "euca-authorize --region #{node["eucalyptus"]["dns"]["domain"]} -P icmp -t -1:-1 -s 0.0.0.0/0 default --debug && euca-authorize --region #{node["eucalyptus"]["dns"]["domain"]} -P tcp -p 22 -s 0.0.0.0/0 default --debug"
+  command "euca-authorize --region #{node["eucalyptus"]["dns-domain"]} -P icmp -t -1:-1 -s 0.0.0.0/0 default --debug && euca-authorize --region #{node["eucalyptus"]["dns-domain"]} -P tcp -p 22 -s 0.0.0.0/0 default --debug"
 end
 
 script "install_image" do
@@ -59,20 +59,20 @@ script "install_image" do
   not_if "euca-describe-images | grep default"
   code <<-EOH
   curl #{node['eucalyptus']['default-img-url']} > default.img
-  euca-install-image --region #{node["eucalyptus"]["dns"]["domain"]} -i default.img -b default -n default -r x86_64 --virtualization-type hvm
+  euca-install-image --region #{node["eucalyptus"]["dns-domain"]} -i default.img -b default -n default -r x86_64 --virtualization-type hvm
   EOH
 end
 
 execute "Ensure default image is public" do
-  command "euca-modify-image-attribute --region #{node["eucalyptus"]["dns"]["domain"]} -l -a all $(euca-describe-images | grep default | grep emi | awk '{print $2}')"
+  command "euca-modify-image-attribute --region #{node["eucalyptus"]["dns-domain"]} -l -a all $(euca-describe-images | grep default | grep emi | awk '{print $2}')"
 end
 
 execute "Wait for resource availability" do
-  command "euca-describe-availability-zones --region #{node["eucalyptus"]["dns"]["domain"]} verbose | grep m1.small | grep -v 0000"
+  command "euca-describe-availability-zones --region #{node["eucalyptus"]["dns-domain"]} verbose | grep m1.small | grep -v 0000"
   retries 50
   retry_delay 10
 end
 
 execute "Running an instance" do
-  command "euca-run-instances --region #{node["eucalyptus"]["dns"]["domain"]} -k my-first-keypair $(euca-describe-images --region #{node["eucalyptus"]["dns"]["domain"]} | grep default | grep emi | cut -f 2)"
+  command "euca-run-instances --region #{node["eucalyptus"]["dns-domain"]} -k my-first-keypair $(euca-describe-images --region #{node["eucalyptus"]["dns-domain"]} | grep default | grep emi | cut -f 2)"
 end

--- a/recipes/create-first-resources.rb
+++ b/recipes/create-first-resources.rb
@@ -49,9 +49,6 @@ execute "Add keypair: my-first-keypair" do
 end
 
 execute "Authorizing SSH and ICMP traffic for default security group" do
-  #command "euca-authorize --region localhost -P icmp -t -1:-1 -s 0.0.0.0/0
-  #default --debug && euca-authorize --region localhost -P tcp -p 22 -s 0.0
-  #.0.0/0 default --debug"
   command "euca-authorize --region #{node["eucalyptus"]["dns"]["domain"]} -P icmp -t -1:-1 -s 0.0.0.0/0 default --debug && euca-authorize --region #{node["eucalyptus"]["dns"]["domain"]} -P tcp -p 22 -s 0.0.0.0/0 default --debug"
 end
 

--- a/recipes/create-first-resources.rb
+++ b/recipes/create-first-resources.rb
@@ -27,7 +27,7 @@ faststart_ini = "/root/.euca/faststart.ini"
 directory '/root/.euca'
 
 execute "Create admin credentials" do
-  command "#{as_admin} euare-useraddkey admin -wld #{node["eucalyptus"]["dns"]["domain"]} -w > #{faststart_ini} --region localhost"
+  command "#{as_admin} euare-useraddkey admin -wld #{node["eucalyptus"]["dns"]["domain"]} -w > #{faststart_ini} --region #{node["eucalyptus"]["dns"]["domain"]}"
   creates faststart_ini
   not_if { ::File.exist? "#{faststart_ini}" }
 end
@@ -36,20 +36,23 @@ bash "Set default region" do
    user "root"
    code <<-EOF
       echo '[global]' >> #{faststart_ini}
-      echo 'default-region = localhost' >> #{faststart_ini}
+      echo 'default-region = #{node["eucalyptus"]["dns"]["domain"]}' >> #{faststart_ini}
    EOF
    not_if "grep -q default-region #{faststart_ini}"
 end
 
 execute "Add keypair: my-first-keypair" do
-  command "euca-create-keypair my-first-keypair >/root/my-first-keypair.pem && chmod 0600 /root/my-first-keypair.pem"
-  not_if "euca-describe-keypairs my-first-keypair"
+  command "euca-create-keypair --region #{node["eucalyptus"]["dns"]["domain"]} my-first-keypair >/root/my-first-keypair.pem && chmod 0600 /root/my-first-keypair.pem"
+  not_if "euca-describe-keypairs --region #{node["eucalyptus"]["dns"]["domain"]} my-first-keypair"
   retries 10
   retry_delay 10
 end
 
 execute "Authorizing SSH and ICMP traffic for default security group" do
-  command "euca-authorize -P icmp -t -1:-1 -s 0.0.0.0/0 default && euca-authorize -P tcp -p 22 -s 0.0.0.0/0 default"
+  #command "euca-authorize --region localhost -P icmp -t -1:-1 -s 0.0.0.0/0
+  #default --debug && euca-authorize --region localhost -P tcp -p 22 -s 0.0
+  #.0.0/0 default --debug"
+  command "euca-authorize --region #{node["eucalyptus"]["dns"]["domain"]} -P icmp -t -1:-1 -s 0.0.0.0/0 default --debug && euca-authorize --region #{node["eucalyptus"]["dns"]["domain"]} -P tcp -p 22 -s 0.0.0.0/0 default --debug"
 end
 
 script "install_image" do
@@ -59,20 +62,20 @@ script "install_image" do
   not_if "euca-describe-images | grep default"
   code <<-EOH
   curl #{node['eucalyptus']['default-img-url']} > default.img
-  euca-install-image -i default.img -b default -n default -r x86_64 --virtualization-type hvm
+  euca-install-image --region #{node["eucalyptus"]["dns"]["domain"]} -i default.img -b default -n default -r x86_64 --virtualization-type hvm
   EOH
 end
 
 execute "Ensure default image is public" do
-  command "euca-modify-image-attribute -l -a all $(euca-describe-images | grep default | grep emi | awk '{print $2}')"
+  command "euca-modify-image-attribute --region #{node["eucalyptus"]["dns"]["domain"]} -l -a all $(euca-describe-images | grep default | grep emi | awk '{print $2}')"
 end
 
 execute "Wait for resource availability" do
-  command "euca-describe-availability-zones verbose | grep m1.small | grep -v 0000"
+  command "euca-describe-availability-zones --region #{node["eucalyptus"]["dns"]["domain"]} verbose | grep m1.small | grep -v 0000"
   retries 50
   retry_delay 10
 end
 
 execute "Running an instance" do
-  command "euca-run-instances -k my-first-keypair $(euca-describe-images | grep default | grep emi | cut -f 2)"
+  command "euca-run-instances --region #{node["eucalyptus"]["dns"]["domain"]} -k my-first-keypair $(euca-describe-images --region #{node["eucalyptus"]["dns"]["domain"]} | grep default | grep emi | cut -f 2)"
 end

--- a/recipes/eucanetd.rb
+++ b/recipes/eucanetd.rb
@@ -4,11 +4,24 @@ require 'chef/version_constraint'
 include_recipe "eucalyptus::default"
 
 # Remove default virsh network which runs its own dhcp server
-execute 'virsh net-destroy default' do
-  ignore_failure true
+if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
+  execute 'virsh net-destroy default' do
+    ignore_failure true
+  end
+  execute 'virsh net-autostart default --disable' do
+    ignore_failure true
+  end
 end
-execute 'virsh net-autostart default --disable' do
-  ignore_failure true
+if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
+  execute 'virsh net-destroy default' do
+    ignore_failure true
+  end
+  execute 'virsh net-autostart default --disable' do
+    ignore_failure true
+  end
+  execute 'virsh net-undefine default' do
+    ignore_failure true
+  end
 end
 
 if node["eucalyptus"]["install-type"] == "packages"
@@ -40,7 +53,7 @@ if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
   if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
     execute "Configure kernel parameters from 70-eucanetd.conf" do
       command "/usr/lib/systemd/systemd-sysctl 70-eucanetd.conf"
-      notifies :run, "execute[Ensure bridge modules loaded into the kernel on NC]", :before
+      notifies :run, "execute[Ensure bridge and br_netfilter modules loaded into the kernel on NC]", :before
     end
   end
 end

--- a/recipes/eucanetd.rb
+++ b/recipes/eucanetd.rb
@@ -37,9 +37,11 @@ if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
   end
 end
 if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
-  execute "Configure kernel parameters from 70-eucanetd.conf" do
-    command "/usr/lib/systemd/systemd-sysctl 70-eucanetd.conf"
-    notifies :run, "execute[Ensure bridge modules loaded into the kernel on NC]", :before
+  if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
+    execute "Configure kernel parameters from 70-eucanetd.conf" do
+      command "/usr/lib/systemd/systemd-sysctl 70-eucanetd.conf"
+      notifies :run, "execute[Ensure bridge modules loaded into the kernel on NC]", :before
+    end
   end
 end
 

--- a/recipes/eucanetd.rb
+++ b/recipes/eucanetd.rb
@@ -53,7 +53,7 @@ if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
   if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
     execute "Configure kernel parameters from 70-eucanetd.conf" do
       command "/usr/lib/systemd/systemd-sysctl 70-eucanetd.conf"
-      notifies :run, "execute[Ensure bridge and br_netfilter modules loaded into the kernel on NC]", :before
+      notifies :run, "execute[Ensure bridge modules loaded into the kernel on NC]", :before
     end
   end
 end

--- a/recipes/eucanetd.rb
+++ b/recipes/eucanetd.rb
@@ -39,7 +39,7 @@ end
 if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
   execute "Configure kernel parameters from 70-eucanetd.conf" do
     command "/usr/lib/systemd/systemd-sysctl 70-eucanetd.conf"
-    notifies :run "execute[Ensure bridge modules loaded into the kernel on NC]", :before
+    notifies :run, "execute[Ensure bridge modules loaded into the kernel on NC]", :before
   end
 end
 

--- a/recipes/eucanetd.rb
+++ b/recipes/eucanetd.rb
@@ -39,7 +39,7 @@ end
 if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
   execute "Configure kernel parameters from 70-eucanetd.conf" do
     command "/usr/lib/systemd/systemd-sysctl 70-eucanetd.conf"
-    notifies :run, "execute[Run systemd-modules-load]", :before
+    notifies :run "execute[Ensure bridge modules loaded into the kernel on NC]", :before
   end
 end
 

--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -172,6 +172,7 @@ if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
     notifies :run, "execute[brctl setfd]", :delayed
     notifies :run, "execute[brctl sethello]", :delayed
     notifies :run, "execute[brctl stp]", :delayed
+    notifies :run, "execute[Configure kernel parameters from 70-eucanetd.conf]", :immediately
   end
 else
   execute "Ensure bridge modules loaded into the kernel on NC" do

--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -166,7 +166,7 @@ end
 
 ## use a different notifier to setup bridge in VPCMIDO mode
 if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
-  execute "Ensure bridge and br_netfilter modules loaded into the kernel on NC" do
+  execute "Ensure bridge modules loaded into the kernel on NC" do
     command "modprobe bridge; modprobe br_netfilter"
     notifies :run, "execute[network-restart]", :immediately
     notifies :run, "execute[brctl setfd]", :delayed

--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -172,7 +172,6 @@ if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
     notifies :run, "execute[brctl setfd]", :delayed
     notifies :run, "execute[brctl sethello]", :delayed
     notifies :run, "execute[brctl stp]", :delayed
-    notifies :run, "execute[Configure kernel parameters from 70-eucanetd.conf]", :immediately
   end
 else
   execute "Ensure bridge modules loaded into the kernel on NC" do

--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -166,8 +166,8 @@ end
 
 ## use a different notifier to setup bridge in VPCMIDO mode
 if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
-  execute "Ensure bridge modules loaded into the kernel on NC" do
-    command '/usr/lib/systemd/systemd-modules-load || :'
+  execute "Ensure bridge and br_netfilter modules loaded into the kernel on NC" do
+    command "modprobe bridge; modprobe br_netfilter"
     notifies :run, "execute[network-restart]", :immediately
     notifies :run, "execute[brctl setfd]", :delayed
     notifies :run, "execute[brctl sethello]", :delayed

--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -167,7 +167,7 @@ end
 ## use a different notifier to setup bridge in VPCMIDO mode
 if node["eucalyptus"]["network"]["mode"] != "VPCMIDO"
   execute "Ensure bridge modules loaded into the kernel on NC" do
-    command "modprobe bridge; modprobe br_netfilter"
+    command "modprobe bridge"
     notifies :run, "execute[network-restart]", :immediately
     notifies :run, "execute[brctl setfd]", :delayed
     notifies :run, "execute[brctl sethello]", :delayed

--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -208,7 +208,7 @@ ruby_block "Sync keys for NC" do
   block do
     Eucalyptus::KeySync.get_node_keys(node)
   end
-  only_if { not Chef::Config[:solo] and node['eucalyptus']['sync-keys'] }
+  only_if { node['eucalyptus']['sync-keys'] }
 end
 
 
@@ -241,6 +241,7 @@ if CephHelper::SetCephRbd.is_ceph?(node) && !node['ceph']
   node.set[:ceph_user_name] = (ceph_keyrings['rbd-user']['name']).sub(/^client./, '')
   node.set[:ceph_keyring_path] = "#{ceph_keyrings['rbd-user']['keyring']}"
   node.set[:ceph_config_path] = "/etc/ceph/ceph.conf"
+  node.save
 
   ceph_config = CephHelper::SetCephRbd.get_configurations(
   node["eucalyptus"]["topology"]["clusters"][cluster_name]["ceph-config"],

--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -241,7 +241,6 @@ if CephHelper::SetCephRbd.is_ceph?(node) && !node['ceph']
   node.set[:ceph_user_name] = (ceph_keyrings['rbd-user']['name']).sub(/^client./, '')
   node.set[:ceph_keyring_path] = "#{ceph_keyrings['rbd-user']['keyring']}"
   node.set[:ceph_config_path] = "/etc/ceph/ceph.conf"
-  node.save
 
   ceph_config = CephHelper::SetCephRbd.get_configurations(
   node["eucalyptus"]["topology"]["clusters"][cluster_name]["ceph-config"],

--- a/recipes/register-components.rb
+++ b/recipes/register-components.rb
@@ -75,7 +75,6 @@ clusters.each do |cluster, info|
       %w(cloud-cert.pem cluster-cert.pem cluster-pk.pem node-cert.pem node-pk.pem vtunpass).each do |key_name|
         cert = Base64.encode64(::File.new("#{cluster_keys_dir}/#{key_name}").read)
         node.set['eucalyptus']['cloud-keys'][cluster][key_name] = cert
-        node.save
       end
     end
     not_if "#{Chef::Config[:solo]}"
@@ -85,7 +84,6 @@ clusters.each do |cluster, info|
       %w(cloud-cert.pem cluster-cert.pem cluster-pk.pem node-cert.pem node-pk.pem vtunpass).each do |key_name|
         cert = Base64.encode64(::File.new("#{cluster_keys_dir}/#{key_name}").read)
         node.default['eucalyptus']['cloud-keys'][cluster][key_name] = cert
-        node.save
       end
     end
     not_if "#{Chef::Config[:solo]}"

--- a/recipes/register-components.rb
+++ b/recipes/register-components.rb
@@ -29,7 +29,6 @@ ruby_block "Upload cloud keys Chef Server" do
   block do
     Eucalyptus::KeySync.upload_cloud_keys(node)
   end
-  not_if "#{Chef::Config[:solo]}"
 end
 
 ##### Register clusters
@@ -75,23 +74,18 @@ clusters.each do |cluster, info|
       %w(cloud-cert.pem cluster-cert.pem cluster-pk.pem node-cert.pem node-pk.pem vtunpass).each do |key_name|
         cert = Base64.encode64(::File.new("#{cluster_keys_dir}/#{key_name}").read)
         node.set['eucalyptus']['cloud-keys'][cluster][key_name] = cert
+        node.save
       end
     end
-    not_if "#{Chef::Config[:solo]}"
   end
   ruby_block "Upload cluster keys Chef Server" do
     block do
       %w(cloud-cert.pem cluster-cert.pem cluster-pk.pem node-cert.pem node-pk.pem vtunpass).each do |key_name|
         cert = Base64.encode64(::File.new("#{cluster_keys_dir}/#{key_name}").read)
         node.default['eucalyptus']['cloud-keys'][cluster][key_name] = cert
+        node.save
       end
     end
-    not_if "#{Chef::Config[:solo]}"
-  end
-  ### In solo mode (ie faststart) ensure that we copy the cluster keys over for the CC
-  execute "Copy keys locally" do
-    command "cp #{cluster_keys_dir}/* #{node["eucalyptus"]["home-directory"]}/var/lib/eucalyptus/keys/"
-    only_if "#{Chef::Config[:solo]}"
   end
 end
 

--- a/recipes/register-components.rb
+++ b/recipes/register-components.rb
@@ -107,6 +107,8 @@ user_facing.each do |uf_ip|
   execute "Register User Facing #{uf_ip}" do
     command "#{register_service} -t user-api -h #{uf_ip} API_#{uf_ip}"
     not_if "#{describe_services} | egrep 'API_#{uf_ip}'"
+    retries 20
+    retry_delay 10
   end
 end
 

--- a/recipes/storage-controller.rb
+++ b/recipes/storage-controller.rb
@@ -32,7 +32,10 @@ if node["eucalyptus"]["set-bind-addr"]
     # Use default gw interface IP
     bind_addr = node["ipaddress"]
   end
-  node.override['eucalyptus']['cloud-opts'] = node['eucalyptus']['cloud-opts'] + " --bind-addr=" + bind_addr
+  if not node['eucalyptus']['cloud-opts'].include?"--bind-addr="
+    Chef::Log.info "Adding --bind-addr to eucalyptus.conf cloud-opts"
+    node.override['eucalyptus']['cloud-opts'] = node['eucalyptus']['cloud-opts'] + " --bind-addr=" + bind_addr
+  end
 end
 
 if node["eucalyptus"]["install-type"] == "packages"

--- a/recipes/storage-controller.rb
+++ b/recipes/storage-controller.rb
@@ -105,7 +105,7 @@ end
 
 ruby_block "Sync keys for SC" do
   block do
-    Eucalyptus::KeySync.get_cluster_keys(node, "sc-1")
+    Eucalyptus::KeySync.get_cluster_keys(node, "sc")
   end
   only_if { not Chef::Config[:solo] and node['eucalyptus']['sync-keys'] }
   notifies :restart, "service[eucalyptus-cloud]", :before
@@ -147,12 +147,14 @@ if CephHelper::SetCephRbd.is_ceph?(node) && !node['ceph']
 end
 
 node['eucalyptus']['topology']['clusters'].each do |cluster, info|
-  Chef::Log.warn("Checking SC bindaddr: #{bind_addr}, ip:#{node["ipaddress"]}, backend:#{info['storage-backend']}, against sc-1:#{info['sc-1']}")
-  if (info['storage-backend'] == 'das' or info['storage-backend'] == 'overlay') and (info['sc-1'] == bind_addr or info['sc-1'] == node["ipaddress"])
-    Chef::Log.info("Enabling tgtd service for storage controller at: #{bind_addr}, backend:#{info['storage-backend']}")
-    service 'tgtd' do
-      action [ :enable, :start ]
-      supports :status => true, :start => true, :stop => true, :restart => true
+  Chef::Log.warn("Checking SC bindaddr: #{bind_addr}, ip:#{node["ipaddress"]}, backend:#{info['storage-backend']}, against sc:#{info['sc']}")
+  info['sc'].each do |sc_ipaddr|
+    if (info['storage-backend'] == 'das' or info['storage-backend'] == 'overlay') and (info['sc'] == bind_addr or sc_ipaddr == node["ipaddress"])
+      Chef::Log.info("Enabling tgtd service for storage controller at: #{bind_addr}, backend:#{info['storage-backend']}")
+      service 'tgtd' do
+        action [ :enable, :start ]
+        supports :status => true, :start => true, :stop => true, :restart => true
+      end
     end
   end
 end

--- a/recipes/storage-controller.rb
+++ b/recipes/storage-controller.rb
@@ -107,7 +107,7 @@ ruby_block "Sync keys for SC" do
   block do
     Eucalyptus::KeySync.get_cluster_keys(node, "sc")
   end
-  only_if { not Chef::Config[:solo] and node['eucalyptus']['sync-keys'] }
+  only_if { node['eucalyptus']['sync-keys'] }
   notifies :restart, "service[eucalyptus-cloud]", :before
 end
 

--- a/recipes/user-facing.rb
+++ b/recipes/user-facing.rb
@@ -91,6 +91,7 @@ ruby_block "Create New Ceph User" do
       new_user = JSON.parse(shell.stdout)
       node.set['eucalyptus']['topology']['objectstorage']['access-key'] = new_user['keys'][0]['access_key']
       node.set['eucalyptus']['topology']['objectstorage']['secret-key'] = new_user['keys'][0]['secret_key']
+      node.save
     end
   end
   only_if { CephHelper::SetCephRbd.is_ceph_radosgw?(node) }
@@ -100,7 +101,7 @@ ruby_block "Sync keys for User Facing Services" do
   block do
     Eucalyptus::KeySync.get_cloud_keys(node)
   end
-  only_if { not Chef::Config[:solo] and node['eucalyptus']['sync-keys'] }
+  only_if { node['eucalyptus']['sync-keys'] }
 end
 
 service "ufs-eucalyptus-cloud" do

--- a/recipes/user-facing.rb
+++ b/recipes/user-facing.rb
@@ -91,7 +91,6 @@ ruby_block "Create New Ceph User" do
       new_user = JSON.parse(shell.stdout)
       node.set['eucalyptus']['topology']['objectstorage']['access-key'] = new_user['keys'][0]['access_key']
       node.set['eucalyptus']['topology']['objectstorage']['secret-key'] = new_user['keys'][0]['secret_key']
-      node.save
     end
   end
   only_if { CephHelper::SetCephRbd.is_ceph_radosgw?(node) }

--- a/recipes/walrus.rb
+++ b/recipes/walrus.rb
@@ -53,7 +53,7 @@ ruby_block "Sync keys for Walrus" do
   block do
     Eucalyptus::KeySync.get_cloud_keys(node)
   end
-  only_if { not Chef::Config[:solo] and node['eucalyptus']['sync-keys'] }
+  only_if { node['eucalyptus']['sync-keys'] }
 end
 
 service "eucalyptus-cloud" do


### PR DESCRIPTION
This pulls up many items to master that were not yet merged from 4.3:
* Use getservicestates helper for objectstorage enabled verification 
* remove modprobe br_netfilter now that NC does it automatically
* add retry delay while registering User Facing service
* only add bind address to cloud opts if it has not already been done 

4.3 faststart changes pulled up:
* use ping vs. dig which is actually part of the centos minimal image
* default to using nip.io for faststart wildcard dns
* Update faststart repos and berks package URL
* add RHEL/CentOS 7.3 support to faststart; point to 4.3.1 cookbooks
* updates for changes to the environment.yml (i.e. dns-domain is now a string as opposed to array)

Others may not be listed here, but are documented in the commits.