### PR TITLE
Call autoconf when building eucalyptus from source

### DIFF
--- a/recipes/install-source.rb
+++ b/recipes/install-source.rb
@@ -156,7 +156,7 @@ git eucalyptus_dir do
   notifies :run, 'execute[install-eucalyptus]', :immediately
 end
 
-build_eucalyptus = "#{java_home} && #{_configure} --prefix=/ \
+build_eucalyptus = "#{java_home} && autoconf && #{_configure} --prefix=/ \
 --disable-bundled-jars \
 --with-apache2-module-dir=/usr/lib64/httpd/modules \
 --with-axis2=/usr/share/axis2-* --with-axis2c=/usr/lib64/axis2c \


### PR DESCRIPTION
Seeing a failure when building from sources:

http://jenkins.qa1.eucalyptus-systems.com/job/Calyptos-v2.0/2433/console

the change in this pull request worked for me.