### PR TITLE
Fix the check for BOOTPROTO to be RHEL-compatible

### DIFF
--- a/recipes/node-controller.rb
+++ b/recipes/node-controller.rb
@@ -91,7 +91,7 @@ bridged_nic_bootproto = `cat #{bridged_nic_file} | grep BOOTPROTO | awk -F'=' '{
 Chef::Log.info "Using BOOTPROTO \"#{bridged_nic_bootproto}\""
 
 if node["eucalyptus"]["network"]["mode"] == "VPCMIDO"
-  if "#{bridged_nic_bootproto}" == "static"
+  if "#{bridged_nic_bootproto}" != "dhcp" and "#{bridged_nic_bootproto}" != "bootp"
     template bridge_file do
       source "ifcfg-br-static-vpcmido.erb"
       mode 0644
@@ -107,7 +107,7 @@ if node["eucalyptus"]["network"]["mode"] == "VPCMIDO"
     end
   end
 else
-  if "#{bridged_nic_bootproto}" == "static"
+  if "#{bridged_nic_bootproto}" != "dhcp" and "#{bridged_nic_bootproto}" != "bootp"
     template bridge_file do
       source "ifcfg-br-static.erb"
       mode 0644


### PR DESCRIPTION
BOOTPROTO=static is the same as BOOTPROTO=none is the same as BOOTPROTO=just-as-long-as-its-not-bootp-or-dhcp

Many systems use BOOTPROTO=none

In /etc/sysconfig/network-scripts/ifup-eth there is only this check:

if ["${BOOTPROTO}" = "bootp" -o "${BOOTPROTO}" = "dhcp" ]; then DYNCONFIG=true

Nothing in RHEL checks for BOOTPROTO=static

Thanks