### PR TITLE
Select image information correctly

### DIFF
--- a/faststart/tutorials/describe-images.sh
+++ b/faststart/tutorials/describe-images.sh
@@ -69,7 +69,7 @@ echo "${normal}"
 
 echo "Now let's review some of the key output of that command:"
 echo ""
-imagelist=`euca-describe-images --region admin@${region}| tail -n 1`
+imagelist=`euca-describe-images --region admin@${region}|grep IMAGE| tail -n 1`
 imageid=`echo $imagelist | awk '{print $2}'`
 imagepath=`echo $imagelist | awk '{print $3}'`
 public=`echo $imagelist | awk '{print $6}'`


### PR DESCRIPTION
Summary:
The euca-describe-images command outputs lines that start with IMAGE or TAGS.  The script only works with lines that start with IMAGE.

Reproducing:
1. run tutorial
2. see "image is the image ID"

Expected
1. run tutorial
2. see "emi-eda0d7cc is the image ID"

This is due to euca-describe-images outputting:
IMAGE   emi-eda0d7cc    eucalyptus-service-image-v3.32/eucalyptus-service-image.raw.manifest.xml        000137454426    availableprivate  x86_64  machine                         instance-store  hvm                                                               
TAG     image   emi-eda0d7cc    provides        imaging,loadbalancing