### PR TITLE
Please leave the cursor the way it was

### DIFF
--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -78,7 +78,7 @@ function coffee()
         sleep $IMG_REFRESH
     done; done
     tput_loop "cud1"
-    tput cvvis
+    tput cnorm
 }
 
 # Check IP inputs to make sure they're valid


### PR DESCRIPTION
Summary:
The "tput cvvis" command makes the cursor very visible which is sometimes too much.
The "tput cnorm" command makes the cursor look normal.

Reproducing:
1. run cloud-in-a-box.sh on the console or other terminal where "tput cvvis" is very different from "tput cnorm".
2. when the script is complete or interrupted with ^c the cursor will look strange.

Expected:
1. run cloud-in-a-box.sh on the console or other terminal where "tput cvvis" is very different from "tput cnorm".
2. when the script is complete or interrupted with ^c the cursor will look like it normally does.