### PR TITLE
bootp is a synonym for dhcp

### DIFF
--- a/faststart/cloud-in-a-box.sh
+++ b/faststart/cloud-in-a-box.sh
@@ -368,7 +368,7 @@ echo ""
 
 # Check to see if the primary network interface is configured to use DHCP.
 # If it is, warn and abort.
-grep -i dhcp /etc/sysconfig/network-scripts/ifcfg-$active_nic
+grep -iE '=dhcp|=bootp'  /etc/sysconfig/network-scripts/ifcfg-$active_nic
 if [ "$?" == "0" ]; then
     echo "====="
     echo "WARNING: we recommend configuring Eucalypus servers to use"


### PR DESCRIPTION
Summary:
BOOTPROTO=bootp is treated the same way that BOOTPROTO=dhcp is.

Reproducing:
1. Set BOOTPROTO=bootp in /etc/sysconfig/network-scripts/ifcfg-eth0 (or other primary NIC configuration file)
2. Run cloud-in-a-box.sh
3. The resulting configuration will have no warnings about using DHCP